### PR TITLE
Make path / target-name handling consistent across POSIX & Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ ybt_bin
 # Python Testing
 .tox
 .coverage
+.pytest_cache
+
+ybtenv/
+.vscode/

--- a/conftest.py
+++ b/conftest.py
@@ -55,6 +55,11 @@ def in_dag_project():
 
 
 @yield_fixture
+def in_yapi_dir():
+    yield from yabt_project_fixture(os.path.join('dag', 'yapi'))
+
+
+@yield_fixture
 def in_pkgmgrs_project():
     yield from yabt_project_fixture('pkgmgrs')
 

--- a/yabt/buildcontext.py
+++ b/yabt/buildcontext.py
@@ -160,9 +160,9 @@ class BuildContext:
         """
         if target_name in self.targets:
             del self.targets[target_name]
-        if split_build_module(target_name) in self.targets_by_module:
-            self.targets_by_module[split_build_module(target_name)].remove(
-                target_name)
+        build_module = split_build_module(target_name)
+        if build_module in self.targets_by_module:
+            self.targets_by_module[build_module].remove(target_name)
 
     def get_target_extraction_context(self, build_file_path: str) -> dict:
         """Return a build file parser target extraction context.

--- a/yabt/builders/proto.py
+++ b/yabt/builders/proto.py
@@ -24,7 +24,7 @@ yabt ProtoBuf builder
 
 import os
 from os.path import dirname, isfile, join, relpath, splitext
-from pathlib import Path
+from pathlib import Path, PurePath
 
 from ostrich.utils.path import commonpath
 
@@ -88,7 +88,7 @@ def proto_builder(build_context, target):
         protoc_cmd.extend(('--cpp_rpcz_out', buildenv_workspace))
     if target.props.gen_python_rpcz:
         protoc_cmd.extend(('--python_rpcz_out', buildenv_workspace))
-    protoc_cmd.extend(join(buildenv_workspace, 'proto', src)
+    protoc_cmd.extend((PurePath(buildenv_workspace) / 'proto' / src).as_posix()
                       for src in target.props.sources)
     build_context.run_in_buildenv(
         target.props.in_buildenv, protoc_cmd, target.props.cmd_env)

--- a/yabt/buildfile_utils.py
+++ b/yabt/buildfile_utils.py
@@ -22,11 +22,12 @@ yabt Build File utils
 """
 
 
-from os.path import normpath, relpath, split
-
+from pathlib import Path
 from .config import Config
 
 
 def to_build_module(build_file_path: str, conf: Config) -> str:
     """Return a normalized build module name for `build_file_path`."""
-    return split(normpath(relpath(build_file_path, conf.project_root)))[0]
+    build_file = Path(build_file_path)
+    root = Path(conf.project_root)
+    return build_file.resolve().relative_to(root).parent.as_posix().strip('.')

--- a/yabt/compat.py
+++ b/yabt/compat.py
@@ -24,7 +24,7 @@ yabt Compatability module
 
 # os.scandir, performant os.walk
 try:
-    # Python 3.5, use builtin implementation
+    # Python 3.5+, use builtin implementation
     # https://docs.python.org/3/library/os.html#os.scandir
     from os import scandir, walk
 except ImportError:

--- a/yabt/config.py
+++ b/yabt/config.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from .extend import Plugin
 from .logging import configure_logging
 from .scm import ScmManager
-from .utils import search_for_parent_dir
+from .utils import norm_proj_path, search_for_parent_dir
 
 
 BUILD_PROJ_FILE = 'YRoot'
@@ -77,11 +77,12 @@ class Config:
         """Return a full path to the build file of `build_module`.
 
         The returned path will always be OS-native, regardless of the format
-        of project_root (native) and build_module (always with '/').
+        of project_root (native) and build_module (with '/').
         """
         project_root = Path(self.project_root)
+        build_module = norm_proj_path(build_module, self.project_root)
         return str(project_root / build_module /
-                   (BUILD_PROJ_FILE if project_root.samefile(build_module)
+                   (BUILD_PROJ_FILE if '' == build_module
                     else self.build_file_name))
 
     def get_workspace_path(self) -> str:

--- a/yabt/docker.py
+++ b/yabt/docker.py
@@ -473,7 +473,8 @@ def build_docker_image(
                 run_installers.extend([
                     'tar -xf {0}/{1} -C {0}'.format(tmp_install, package_tar),
                     'cd {}/{}'.format(tmp_install, custom_installer.name),
-                    './{}'.format(custom_installer.install_script),
+                    'cat {} | tr -d \'\\r\' | bash'.format(
+                        custom_installer.install_script),
                 ])
             dockerfile.extend([
                 'COPY {} {}\n'.format(packages_dir, tmp_install),

--- a/yabt/docker.py
+++ b/yabt/docker.py
@@ -30,6 +30,7 @@ from collections import defaultdict, deque
 import os
 from os.path import (
     abspath, basename, dirname, isfile, join, relpath, samefile, split)
+from pathlib import PurePath
 import platform
 import shutil
 
@@ -563,8 +564,10 @@ def build_docker_image(
     if entrypoint:
         # TODO(itamar): Consider adding tini as entrypoint also if given
         # Docker CMD without a Docker ENTRYPOINT?
+        entrypoint[0] = PurePath(entrypoint[0]).as_posix()
         if full_path_cmd:
-            entrypoint[0] = join('/usr/src/app', entrypoint[0])
+            entrypoint[0] = (PurePath('/usr/src/app') /
+                             entrypoint[0]).as_posix()
         if build_context.conf.with_tini_entrypoint:
             entrypoint = ['tini', '--'] + entrypoint
         dockerfile.append(
@@ -573,8 +576,9 @@ def build_docker_image(
 
     # Add CMD (one layer)
     if cmd:
+        cmd[0] = PurePath(cmd[0]).as_posix()
         if full_path_cmd:
-            cmd[0] = join('/usr/src/app', cmd[0])
+            cmd[0] = (PurePath('/usr/src/app') / cmd[0]).as_posix()
         dockerfile.append(
             'CMD [{}]\n'.format(', '.join(format_docker_cmd(cmd))))
 

--- a/yabt/docker_test.py
+++ b/yabt/docker_test.py
@@ -87,8 +87,8 @@ def test_package_managers_install_order(basic_conf):
         'apt-transport-https curl wget && rm -rf /var/lib/apt/lists/*\n',
         'COPY packages1 /tmp/install1\n',
         'RUN tar -xf /tmp/install1/node.tar.gz -C /tmp/install1 && '
-        'cd /tmp/install1/node && ./install-nodejs.sh && cd / && '
-        'rm -rf /tmp/install1\n',
+        'cd /tmp/install1/node && cat install-nodejs.sh | tr -d \'\\r\' | bash'
+        ' && cd / && rm -rf /tmp/install1\n',
         'RUN apt-get update -y && apt-get install --no-install-recommends -y '
         'ruby2.2 ruby2.2-dev && rm -rf /var/lib/apt/lists/*\n',
         'COPY requirements_pip_1.txt /usr/src/\n',

--- a/yabt/target_extraction.py
+++ b/yabt/target_extraction.py
@@ -23,7 +23,6 @@ yabt target extraction module
 
 
 from numbers import Number
-from os.path import join, normpath
 import types
 
 from ostrich.utils.collections import listify

--- a/yabt/target_extraction_test.py
+++ b/yabt/target_extraction_test.py
@@ -22,6 +22,8 @@ yabt Target extraction tests
 """
 
 
+from os.path import join
+
 import pytest
 
 from .buildcontext import BuildContext
@@ -180,7 +182,7 @@ def test_typed_args_valid_non_default():
     assert target.props == {'name': 'spams:my-spam', 'foo': 'foo',
                             'bar': 'bar', 'deps': ['hams:my-ham'],
                             'cats': ['my cat', 'other cat'],
-                            'cat_list': 'lists/from-vet-4',
+                            'cat_list': join('lists', 'from-vet-4'),
                             'packaging_params': {}, 'runtime_params': {}}
 
 
@@ -193,5 +195,5 @@ def test_file_arg_from_project_root():
     handle_typed_args(target, Plugin.builders['Spam'], 'spams')
     assert target.props == {'name': 'spams:my-spam', 'foo': 'foo',
                             'bar': 'bar', 'deps': [], 'cats': [],
-                            'cat_list': 'lists/from-vet-4',
+                            'cat_list': join('lists', 'from-vet-4'),
                             'packaging_params': {}, 'runtime_params': {}}

--- a/yabt/utils.py
+++ b/yabt/utils.py
@@ -128,7 +128,7 @@ def norm_proj_path(path, build_module):
     """Return a normalized path for the `path` observed in `build_module`.
 
     The normalized path is "normalized" (in the `os.path.normpath` sense),
-    and relative from the project root directory.
+    relative from the project root directorym, and OS-native.
 
     Supports making references from project root directory by prefixing the
     path with "//".
@@ -148,20 +148,21 @@ def norm_proj_path(path, build_module):
         raise ValueError("Invalid path: `{}' - use '//' to start from "
                          "project root".format(path))
 
+    if build_module == '//':
+        build_module = ''
     norm = normpath(join(build_module, path))
-    if norm == '.':
-        return ''
     if norm.startswith('..'):
         raise ValueError(
             "Invalid path `{}' - must remain inside project sandbox"
             .format(path))
-    return norm
+    return norm.strip('.')
 
 
 def search_for_parent_dir(start_at: str=None, with_files: set=None,
                           with_dirs: set=None) -> str:
     """Return absolute path of first parent directory of `start_at` that
-       contains a file named `BUILD_PROJ_FILE` (including `start_at`).
+       contains all files `with_files` and all dirs `with_dirs`
+       (including `start_at`).
 
     If `start_at` not specified, start at current working directory.
 


### PR DESCRIPTION
Fixes non-Docker tests, though Docker-tests are still broken (and not covered by AppVeyor)