### PR TITLE
Automate release to PyPI using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,13 @@ install:
 # command to run tests
 script:
   - make test
+
+deploy:
+  provider: pypi
+  user: resonai
+  password:
+    secure: e2V0IB6eqYyVCnQV/3LqV9CouCAkUfRcAj8cfG/vlkQtz3vWayIHWB+rCTeQIgU3hDYVJF7NfD91LyTjvrEUTx+ejQj8JZL55bDE/3/KpS71aE0/27fFetzA57JOD7MDGbjOszqb5cGCIwjb2z68sUxLct0VSXwJE2h7xRX4O6TcrlRF9YzY/DFGG61RwkkH9Sh9mN376x/yLrE4iqgAfjyX52ps7VNe1zBHIOYphrnYus9Nzn6zIQkkqPaIZn8u9GQtDVgKXYJZkSE9MOyUe2vcyXFtHQ7gVs1pQsa8kUvt0z/uKNQqAhj/2hk8ksMvo8z+t73Cv43qjlO0kAymN71VmPaR3iJSAxh9oJQQPEaewcCXlwlzFnR2sr/k4m2z8etfOrxziKUD/odEoQjhpuOv2CfkBh0ZYttFWTZwa+An8cCffjLF3JQtuvijg/IDuan9BQv+PGfsvWu4hO8xjrSxXAXW3+MGwECKYffHDfUl69UzgogdKhqUoM9CV+XUPHeWOpovh8VBR921o1opvslGyIFN1uEru+IwZjPlKkqzBhyxeBNEtO1vnFhDPO6mSHDzjS/ISJBhYrlL9pCpvleTSj8rY5fq+l4S/vf1nUUeF2r+8ys7hw9MUnqGH8gBq62KHGEU1UtLYgfhu0gX9qCdYb3FRMSD97/b/bqnNls=
+  on:
+    tags: true
+    distributions: sdist bdist_wheel
+    repo: resonai/ybt

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ help:
 	@echo '   make dist       Build source & wheel distributions              '
 	@echo '   make clean      Clean build & dist output directories           '
 	@echo '   make pypi       Clean, build dist, and upload to PyPI (twine)   '
+	@echo '   make release    Bump version, tag & push (trigger Travis deploy)'
 	@echo '                                                                   '
 
 test:
@@ -41,4 +42,7 @@ pypi: clean dist
 	twine upload dist/*
 	@echo "Finished uploading version to PyPI"
 
-.PHONY: help test tox lint dist clean pypi
+release:
+	./scripts/release.sh
+
+.PHONY: help test tox lint dist clean pypi release

--- a/scripts/bumpver.py
+++ b/scripts/bumpver.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 Resonai Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Release helper script
+
+Print to stdout the semantic +1 of the current version number.
+"""
+
+from distutils.version import LooseVersion
+
+import yabt
+
+v = LooseVersion(yabt.__version__).version
+print('.'.join(map(str, v[:-1] + [v[-1] + 1])))

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 Resonai Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if ! git diff-index --quiet HEAD --; then
+    echo "ERROR: Found local changes - can't release."
+    exit 1
+fi
+
+if [ $( git symbolic-ref HEAD ) != "refs/heads/master" ]; then
+    echo "ERROR: Not on 'master' branch. Please switch to master first."
+    exit 1
+fi
+
+CUR_VER="$( python -c 'import yabt; print(yabt.__version__)' )"
+echo "Current version number is $CUR_VER"
+AUTO_NEW_VER="$( ./scripts/bumpver.py )"
+read -p "New version number ($AUTO_NEW_VER): " USER_NEW_VER
+NEW_VER=${USER_NEW_VER:-$AUTO_NEW_VER}
+if ! python -c 'from distutils.version import LooseVersion as LV; import sys; \
+        sys.exit(int(LV("'$NEW_VER'") <= LV("'$CUR_VER'")))'; then
+    echo "ERROR: New version must be greater than old version!"
+    exit 1
+fi
+sed -i.bak "s/__version__ = .*/__version__ = '$NEW_VER'/" yabt/__init__.py
+rm yabt/__init__.py.bak
+echo "Bumped version number to $NEW_VER"
+git add yabt/__init__.py
+git commit -m "Bump version $NEW_VER"
+git tag "v$NEW_VER"
+git push origin master
+git push origin "v$NEW_VER"


### PR DESCRIPTION
- Release is triggered from Travis CI when a git tag is pushed
- A `make release` command is added to automate version bumping and tagging

Fixes #27