### PR TITLE
Make the cmd CLI arg mandatory

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -76,13 +76,13 @@ def in_cpp_project():
 
 @yield_fixture
 def basic_conf():
-    conf = init_and_get_conf(['--non-interactive'])
+    conf = init_and_get_conf(['--non-interactive', 'build'])
     yabt.extend.Plugin.load_plugins(conf)
     yield conf
 
 
 @yield_fixture()
 def debug_conf():
-    conf = init_and_get_conf(['--non-interactive', '--flavor', 'debug'])
+    conf = init_and_get_conf(['--non-interactive', '-f', 'debug', 'build'])
     yabt.extend.Plugin.load_plugins(conf)
     yield conf

--- a/yabt/cli.py
+++ b/yabt/cli.py
@@ -111,9 +111,7 @@ def make_parser(project_config_file: str) -> configargparse.ArgumentParser:
                    help='Whether to log to STDOUT')
         PARSER.add('--loglevel', default='INFO', choices=LOG_LEVELS_CHOICES,
                    help='Log level threshold')
-        PARSER.add('cmd',
-                   choices=['build', 'tree', 'version', 'list-builders'],
-                   nargs='?', default='build')
+        PARSER.add('cmd', choices=['build', 'test', 'tree', 'version'])
         PARSER.add('targets', nargs='*')
     return PARSER
 


### PR DESCRIPTION
Allows removing the nargs='?', thus simplifying the CLI