### PR TITLE
Refactor docker & dockerapp builders to share duplicate code

### DIFF
--- a/yabt/builders/docker.py
+++ b/yabt/builders/docker.py
@@ -84,8 +84,11 @@ def docker_image_manipulate_target(build_context, target):
     target.deps.append(target.props.base_image)
 
 
-@register_build_func('DockerImage')
-def docker_image_builder(build_context, target):
+def docker_builder(build_context, target, entrypoint=None, ybt_bin_path=None):
+    if entrypoint is None:
+        entrypoint = target.props.get('docker_entrypoint')
+    if ybt_bin_path is None:
+        ybt_bin_path = target.props.get('ybt_bin_path')
     metadata = (
         {'image_id': target.image_id} if target.image_id else
         build_docker_image(
@@ -97,14 +100,19 @@ def docker_image_builder(build_context, target):
             env=target.props.env,
             work_dir=target.props.work_dir,
             truncate_common_parent=target.props.truncate_common_parent,
-            entrypoint=target.props.docker_entrypoint,
-            cmd=target.props.docker_cmd,
+            entrypoint=entrypoint,
+            cmd=target.props.get('docker_cmd'),
             full_path_cmd=target.props.full_path_cmd,
             distro=target.props.distro,
             image_caching_behavior=target.props.image_caching_behavior,
             runtime_params=target.props.runtime_params,
-            ybt_bin_path=target.props.ybt_bin_path,
+            ybt_bin_path=ybt_bin_path,
             build_user=target.props.build_user,
             run_user=target.props.run_user,
             labels=target.props.docker_labels))
     build_context.register_target_artifact_metadata(target, metadata)
+
+
+@register_build_func('DockerImage')
+def docker_image_builder(build_context, target):
+    docker_builder(build_context, target)

--- a/yabt/builders/dockerapp.py
+++ b/yabt/builders/dockerapp.py
@@ -28,6 +28,7 @@ from os.path import join
 
 from ostrich.utils.collections import listify
 
+from .docker import docker_builder
 from ..docker import build_docker_image, get_image_name
 from ..extend import PropType as PT, register_builder_sig
 from .. import target_utils
@@ -54,25 +55,5 @@ def register_app_builder_sig(builder_name, sig=None, docstring=None):
 
 def build_app_docker_and_bin(build_context, target, **kwargs):
     build_module, bin_name = target_utils.split(target.name)
-    ybt_bin_path = join(build_context.get_bin_dir(build_module), bin_name)
-    metadata = (
-        {'image_id': target.image_id} if target.image_id else
-        build_docker_image(
-            build_context,
-            name=get_image_name(target),
-            tag=target.props.image_tag,
-            base_image=build_context.targets.get(target.props.base_image),
-            deps=build_context.walk_target_deps_topological_order(target),
-            env=target.props.env,
-            work_dir=target.props.work_dir,
-            truncate_common_parent=target.props.truncate_common_parent,
-            entrypoint=kwargs.get('entrypoint'),
-            full_path_cmd=target.props.full_path_cmd,
-            distro=target.props.distro,
-            image_caching_behavior=target.props.image_caching_behavior,
-            runtime_params=target.props.runtime_params,
-            ybt_bin_path=ybt_bin_path,
-            build_user=target.props.build_user,
-            run_user=target.props.run_user,
-            labels=target.props.docker_labels))
-    build_context.register_target_artifact_metadata(target, metadata)
+    docker_builder(build_context, target, kwargs.get('entrypoint'),
+                   join(build_context.get_bin_dir(build_module), bin_name))

--- a/yabt/graph_test.py
+++ b/yabt/graph_test.py
@@ -213,6 +213,25 @@ def test_prebuilt_targets_case1(basic_conf):
             set(build_context.target_graph.nodes))
 
 
+@slow
+@pytest.mark.usefixtures('in_caching_project')
+def test_prebuilt_targets_build_base_image(basic_conf):
+    """Test pre-built targets when building base images.
+
+    When `--build-base-images` is specified, all targets should be built,
+    regardless of base-image status.
+    """
+    basic_conf.build_base_images = True
+    basic_conf.targets = [':builder']
+    build_context = BuildContext(basic_conf)
+    populate_targets_graph(build_context, basic_conf)
+    pre_built = get_prebuilt_targets(build_context)
+    assert set() == pre_built
+    assert (set((':builder', ':builder-base', ':build-tools',
+                 ':tools', ':unzip', ':ubuntu')) ==
+            set(build_context.target_graph.nodes))
+
+
 @pytest.mark.usefixtures('in_dag_project')
 def test_target_graph(basic_conf):
     build_context = BuildContext(basic_conf)


### PR DESCRIPTION
Here's the unification you asked for

Also added a missing test for the pre-built targets (checking the `--build-base-images` works as expected)