### PR TITLE
Misc cache fixes

### DIFF
--- a/yabt/buildcontext.py
+++ b/yabt/buildcontext.py
@@ -408,8 +408,23 @@ class BuildContext:
                 target.done()
                 return
             try:
-                # check if cache can be used to skip building target
+                # call pre-build hook, if one exists
+                if hasattr(target, 'pre_build_hook'):
+                    logger.debug('Calling pre-build hook for target {}',
+                                 target.name)
+                    pre_build_hook = getattr(target, 'pre_build_hook')
+                    pre_build_hook(self, target)
+                # note: running compute hash here so the hash is not affected
+                # by the build func itself (and may change based on whether
+                # the build was cached or not), but not earlier than here,
+                # so all previous nodes have already been built, including
+                # artifacts that this target may rely on in hacky ways, such
+                # as following ExtCommand or Grunt builder with a FileGroup
+                # builder that collects generated files that are not handled
+                # as "real artifacts"...
+                # TODO: fix this...
                 target.compute_hash(self)
+                # check if cache can be used to skip building target
                 build_cached, test_cached = False, False
                 if self.can_use_cache(target):
                     build_cached, test_cached = load_target_from_cache(

--- a/yabt/buildcontext.py
+++ b/yabt/buildcontext.py
@@ -409,6 +409,7 @@ class BuildContext:
                 return
             try:
                 # check if cache can be used to skip building target
+                target.compute_hash(self)
                 build_cached, test_cached = False, False
                 if self.can_use_cache(target):
                     build_cached, test_cached = load_target_from_cache(

--- a/yabt/graph.py
+++ b/yabt/graph.py
@@ -302,8 +302,8 @@ def populate_targets_graph(build_context, conf: Config):
             ' -> '.join(cycle)
             for cycle in networkx.simple_cycles(build_context.target_graph))
         raise RuntimeError('Detected cycles in build graph!\n' + cycles)
-    for target_name in topological_sort(build_context.target_graph):
-        build_context.targets[target_name].compute_hash(build_context)
+    # for target_name in topological_sort(build_context.target_graph):
+    #     build_context.targets[target_name].compute_hash(build_context)
     logger.info('Finished parsing build graph with {} nodes and {} edges',
                 build_context.target_graph.order(),
                 build_context.target_graph.size())

--- a/yabt/graph.py
+++ b/yabt/graph.py
@@ -302,8 +302,6 @@ def populate_targets_graph(build_context, conf: Config):
             ' -> '.join(cycle)
             for cycle in networkx.simple_cycles(build_context.target_graph))
         raise RuntimeError('Detected cycles in build graph!\n' + cycles)
-    # for target_name in topological_sort(build_context.target_graph):
-    #     build_context.targets[target_name].compute_hash(build_context)
     logger.info('Finished parsing build graph with {} nodes and {} edges',
                 build_context.target_graph.order(),
                 build_context.target_graph.size())

--- a/yabt/target_utils_test.py
+++ b/yabt/target_utils_test.py
@@ -98,7 +98,7 @@ _EXP_JSON = """{
     "builder_name": "CppApp",
     "deps": [
         "9622d221dd088a77b148ceec6a9f6aee",
-        "cd8ef6049ebe0e2528a26ac1dfaa6aeb"
+        "c6bf2ffb8837d4a66b4efbd7ec642bac"
     ],
     "flavor": null,
     "name": "app:hello-prog-app",
@@ -116,7 +116,7 @@ _EXP_JSON = """{
         "image_name": null,
         "image_tag": "latest",
         "main": [
-            "cd8ef6049ebe0e2528a26ac1dfaa6aeb"
+            "c6bf2ffb8837d4a66b4efbd7ec642bac"
         ],
         "packaging_params": {},
         "run_user": null,
@@ -132,7 +132,7 @@ def test_target_hash_and_json(basic_conf):
     build_context = BuildContext(basic_conf)
     basic_conf.targets = ['app:hello-prog-app']
     populate_targets_graph(build_context, basic_conf)
-    assert ('cd8ef6049ebe0e2528a26ac1dfaa6aeb' ==
+    assert ('c6bf2ffb8837d4a66b4efbd7ec642bac' ==
             build_context.targets['app:hello-prog'].hash(build_context))
     assert ('9622d221dd088a77b148ceec6a9f6aee' ==
             build_context.targets[':proto-builder'].hash(build_context))
@@ -148,7 +148,7 @@ def test_hashify_targets(basic_conf):
     populate_targets_graph(build_context, basic_conf)
     assert [
         '9622d221dd088a77b148ceec6a9f6aee',
-        'cd8ef6049ebe0e2528a26ac1dfaa6aeb',
+        'c6bf2ffb8837d4a66b4efbd7ec642bac',
     ] == hashify_targets(['app:hello-prog', ':proto-builder'], build_context)
 
 


### PR DESCRIPTION
- Push down target hash computing from graph population to graph build
- Add pre-build hook on target that is *always* called before hashing & building a target (even if it's cached), but after all dependencies have been built (or loaded from cache)
- Use pre-build hook in C++ builders to add compiler_config to target props for hashing
- Move a bunch of props manipulations from build-func to target extraction hook to consider in target hashing (ProtoBuilder, PythonTest, C++ builders / testers)
- Fix bug in ProtoBuilder that doesn't manipulate packaging-params (injecting PYTHONPATH) if target is loaded from cache