### PR TITLE
Print intermediate failures for easier debug

### DIFF
--- a/yabt/buildcontext.py
+++ b/yabt/buildcontext.py
@@ -289,6 +289,8 @@ class BuildContext:
                             self.skipped_nodes.append(affected_node)
                             graph_copy.remove_node(affected_node)
                     if self.conf.continue_after_fail:
+                        logger.info('Failed target: {} due to error: {}',
+                                    target.name, ex)
                         produced_event.set()
                     else:
                         failed_event.set()


### PR DESCRIPTION
During continue-after-fail it's sometimes useful to find what failed before everything else finishes.