### PR TITLE
remove no-cache flag since build fails with that flag

### DIFF
--- a/yabt/__init__.py
+++ b/yabt/__init__.py
@@ -23,5 +23,5 @@ yabt root package
 
 
 __author__ = 'Itamar Ostricher'
-__version__ = '0.3.16'
+__version__ = '0.3.17'
 __oneliner__ = 'Yet another Build Tool'

--- a/yabt/__init__.py
+++ b/yabt/__init__.py
@@ -23,5 +23,5 @@ yabt root package
 
 
 __author__ = 'Itamar Ostricher'
-__version__ = '0.3.17'
+__version__ = '0.3.16'
 __oneliner__ = 'Yet another Build Tool'

--- a/yabt/docker.py
+++ b/yabt/docker.py
@@ -472,7 +472,7 @@ def build_docker_image(
                 dockerfile.extend([
                     'COPY {} /usr/src/\n'.format(req_fname),
                     'RUN {upgrade_pip}'
-                    '{pip} install --no-cache-dir -r /usr/src/{reqs}\n'
+                    '{pip} install  -r /usr/src/{reqs}\n'
                     .format(upgrade_pip=upgrade_pip, pip=pkg_type,
                             reqs=req_fname)
                 ])

--- a/yabt/docker.py
+++ b/yabt/docker.py
@@ -472,7 +472,7 @@ def build_docker_image(
                 dockerfile.extend([
                     'COPY {} /usr/src/\n'.format(req_fname),
                     'RUN {upgrade_pip}'
-                    '{pip} install  -r /usr/src/{reqs}\n'
+                    '{pip} install -r /usr/src/{reqs}\n'
                     .format(upgrade_pip=upgrade_pip, pip=pkg_type,
                             reqs=req_fname)
                 ])

--- a/yabt/docker_test.py
+++ b/yabt/docker_test.py
@@ -88,7 +88,7 @@ def test_package_managers_install_order(basic_conf):
         'ruby2.3 ruby2.3-dev && rm -rf /var/lib/apt/lists/*\n',
         'COPY requirements_pip_1.txt /usr/src/\n',
         'RUN pip install --no-cache-dir --upgrade pip && '
-        'pip install  -r /usr/src/requirements_pip_1.txt\n',
+        'pip install -r /usr/src/requirements_pip_1.txt\n',
         'RUN npm install left-pad --global\n',
         'RUN gem install compass\n',
         'COPY requirements_pip_2.txt /usr/src/\n',

--- a/yabt/docker_test.py
+++ b/yabt/docker_test.py
@@ -88,11 +88,11 @@ def test_package_managers_install_order(basic_conf):
         'ruby2.3 ruby2.3-dev && rm -rf /var/lib/apt/lists/*\n',
         'COPY requirements_pip_1.txt /usr/src/\n',
         'RUN pip install --no-cache-dir --upgrade pip && '
-        'pip install --no-cache-dir -r /usr/src/requirements_pip_1.txt\n',
+        'pip install  -r /usr/src/requirements_pip_1.txt\n',
         'RUN npm install left-pad --global\n',
         'RUN gem install compass\n',
         'COPY requirements_pip_2.txt /usr/src/\n',
-        'RUN pip install --no-cache-dir -r /usr/src/requirements_pip_2.txt\n',
+        'RUN pip install -r /usr/src/requirements_pip_2.txt\n',
         'WORKDIR /usr/src/app\n',
         'USER root\n',
         'CMD ["foo"]\n',


### PR DESCRIPTION
This is the pip source which crash

# TODO: This check fails if --no-cache-dir is set. And yet we
        #       might be able to build into the ephemeral cache, surely?
        building_is_possible = self._wheel_dir or (
            autobuilding and self.wheel_cache.cache_dir
        )
        assert building_is_possible