### PR TITLE
Dot improvements - issue 106

### DIFF
--- a/yabt/cli.py
+++ b/yabt/cli.py
@@ -123,6 +123,9 @@ def make_parser(project_config_file: str) -> configargparse.ArgumentParser:
                    help='Whether to log to STDOUT')
         PARSER.add('--loglevel', default='INFO', choices=LOG_LEVELS_CHOICES,
                    help='Log level threshold')
+        PARSER.add('--show-buildenv-deps', type=bool, default=False,
+                   help='When runing dot, if set to True than the buildenv '
+                        'targets are printed to the graph too')
         PARSER.add('cmd', choices=['build', 'dot', 'test', 'tree', 'version'])
         PARSER.add('targets', nargs='*')
     return PARSER

--- a/yabt/config.py
+++ b/yabt/config.py
@@ -69,6 +69,7 @@ class Config:
         'with_tini_entrypoint',
         # logging-related
         'loglevel', 'logtostderr', 'logtostdout',
+        'show_buildenv_deps',
     ))
 
     def __init__(self, args, project_root_dir: str, work_dir: str,

--- a/yabt/graph.py
+++ b/yabt/graph.py
@@ -27,6 +27,7 @@ from os.path import relpath
 import networkx
 from networkx.algorithms import dag
 
+from .caching import load_target_from_cache
 from .buildfile_parser import process_build_file
 from .compat import walk
 from .config import Config
@@ -326,8 +327,10 @@ def populate_targets_graph(build_context, conf: Config):
 def write_dot(build_context, conf: Config, out_f):
     """Write build graph in dot format to `out_f` file-like object."""
     out_f.write('strict digraph  {\n')
-    out_f.writelines('  "{}";\n'.format(node)
-                     for node in build_context.target_graph.nodes)
+    for node in build_context.target_graph.nodes:
+        cached = load_target_from_cache(build_context.targets[node], build_context)[0]
+        color = '[color="grey"]' if cached else ''
+        out_f.write('  "{}" {};\n'.format(node, color))
     out_f.writelines('  "{}" -> "{}";\n'.format(u, v)
                      for u, v in build_context.target_graph.edges)
     out_f.write('}\n\n')

--- a/yabt/graph.py
+++ b/yabt/graph.py
@@ -27,7 +27,7 @@ from os.path import relpath
 import networkx
 from networkx.algorithms import dag
 
-from .caching import load_target_from_cache
+from yabt import caching
 from .buildfile_parser import process_build_file
 from .compat import walk
 from .config import Config
@@ -328,8 +328,8 @@ def write_dot(build_context, conf: Config, out_f):
     """Write build graph in dot format to `out_f` file-like object."""
     out_f.write('strict digraph  {\n')
     for node in build_context.target_graph.nodes:
-        cached = load_target_from_cache(build_context.targets[node], build_context)[0]
-        color = '[color="grey"]' if cached else ''
+        cached = caching.load_target_from_cache(build_context.targets[node], build_context)[0]
+        color = '[fillcolor="grey",style=filled]' if cached else ''
         out_f.write('  "{}" {};\n'.format(node, color))
     out_f.writelines('  "{}" -> "{}";\n'.format(u, v)
                      for u, v in build_context.target_graph.edges)

--- a/yabt/graph.py
+++ b/yabt/graph.py
@@ -334,7 +334,7 @@ def write_dot(build_context, conf: Config, out_f):
     """Write build graph in dot format to `out_f` file-like object."""
     buildenvs = set(target.buildenv for target in
                     build_context.targets.values() if target.buildenv is not None)
-    buildenv_targets = set()
+    buildenv_targets = set(buildenvs)
     for buildenv in buildenvs:
         buildenv_targets = buildenv_targets.union(
             descendants(build_context.target_graph, buildenv))

--- a/yabt/graph.py
+++ b/yabt/graph.py
@@ -40,6 +40,12 @@ from .utils import yprint
 logger = make_logger(__name__)
 
 
+TARGETS_COLORS = {'Python': 'red', 'PythonTest': 'pink',
+                  'PythonPackage': 'purple', 'CppLib': 'blue',
+                  'AptPackage': 'brown4', 'CostomInstaller': 'brown',
+                  'Proto': 'green'}
+
+
 def stable_reverse_topological_sort(graph):
     """Return a list of nodes in topological sort order.
 
@@ -329,8 +335,9 @@ def write_dot(build_context, conf: Config, out_f):
     out_f.write('strict digraph  {\n')
     for node in build_context.target_graph.nodes:
         cached = caching.load_target_from_cache(build_context.targets[node], build_context)[0]
-        color = '[fillcolor="grey",style=filled]' if cached else ''
-        out_f.write('  "{}" {};\n'.format(node, color))
+        fillcolor = 'fillcolor="grey",style=filled' if cached else ''
+        color = TARGETS_COLORS.get(build_context.targets[node].builder_name, 'black')
+        out_f.write('  "{}" [color="{}",{}];\n'.format(node, color, fillcolor))
     out_f.writelines('  "{}" -> "{}";\n'.format(u, v)
                      for u, v in build_context.target_graph.edges)
     out_f.write('}\n\n')


### PR DESCRIPTION
* print cached nodes in grey color
* add boundary colors by target type
* add a possibility to not show buildenv targets in the graph