### PR TITLE
Exceptions bug

### DIFF
--- a/yabt/buildcontext.py
+++ b/yabt/buildcontext.py
@@ -36,7 +36,7 @@ from time import sleep, time
 
 import networkx as nx
 from colorama import Fore, Style
-from ostrich.utils.proc import run
+from ostrich.utils.proc import run, CalledProcessError
 from ostrich.utils.text import get_safe_path
 
 from .caching import (get_prebuilt_targets, load_target_from_cache,
@@ -279,8 +279,9 @@ class BuildContext:
             def fail_notifier(ex):
                 """Mark target as failed, taking it and ancestors
                    out of the queue"""
-                sys.stdout.write(ex.stdout.decode('utf-8'))
-                sys.stderr.write(ex.stderr.decode('utf-8'))
+                if isinstance(ex, CalledProcessError):
+                    sys.stdout.write(ex.stdout.decode('utf-8'))
+                    sys.stderr.write(ex.stderr.decode('utf-8'))
                 if graph_copy.has_node(target.name):
                     self.failed_nodes[target.name] = ex
                     # removing all ancestors (nodes that depend on this one)

--- a/yabt/buildcontext.py
+++ b/yabt/buildcontext.py
@@ -407,9 +407,9 @@ class BuildContext:
             kwargs['stdout'] = PIPE
         result = run(docker_run, check=True, **kwargs)
         if kwargs['stdout'] is PIPE:
-            sys.stdout.write(result.stdout)
+            sys.stdout.write(result.stdout.decode('utf-8'))
         if kwargs['stderr'] is PIPE:
-            sys.stderr.write(result.stderr)
+            sys.stderr.write(result.stderr.decode('utf-8'))
         return result
 
     def build_target(self, target: Target):

--- a/yabt/buildcontext.py
+++ b/yabt/buildcontext.py
@@ -279,6 +279,9 @@ class BuildContext:
             def fail_notifier(ex):
                 """Mark target as failed, taking it and ancestors
                    out of the queue"""
+                # TODO(Dana) separate "failed to build target" errors from
+                # "failed to run" errors.
+                # see: https://github.com/resonai/ybt/issues/124
                 if isinstance(ex, CalledProcessError):
                     sys.stdout.write(ex.stdout.decode('utf-8'))
                     sys.stderr.write(ex.stderr.decode('utf-8'))


### PR DESCRIPTION
2 different bugs:
in `run_in_buildenv` - result.stdout is bytes and not str
This bug helped us see a bug in handling errors: we assume the error is CalledProcessError and print the exception's stdout and stderr.
But, If there is a bug in YBT the exception get there - but it has no attribute stdout / stderr.

In the future the right thing will be to separate error handling of build / test failures from ybt errors: https://github.com/resonai/ybt/issues/124