### PR TITLE
create the directory before copying

### DIFF
--- a/yabt/caching.py
+++ b/yabt/caching.py
@@ -27,7 +27,7 @@ to rerun "cached" tests on machines with different hardware (for example).
 import itertools
 import json
 from os import makedirs
-from os.path import isdir, isfile, join, relpath, split
+from os.path import isdir, isfile, join, relpath, split, dirname
 import shutil
 from time import time
 
@@ -272,6 +272,7 @@ def restore_artifact(src_path: str, artifact_hash: str, conf: Config):
             rmnode(abs_src_path)
         logger.debug('Restoring cached artifact {} to {}',
                      artifact_hash, src_path)
+        makedirs(dirname(abs_src_path), exist_ok=True)
         shutil.copy(cached_artifact_path, abs_src_path)
         return True
     logger.debug('No cached artifact for {} with hash {}',


### PR DESCRIPTION
This is to fix the bug e have in parazit right now.
When restore an artifact from the cache, if the directory we are trying to restore the artifact to doesn't exist (a directory under yabtwork), we get an error.
So now I added a fix that before copying the artifact we create the dest dir.

I think that the reason it happened now is that when we have a global cache, this situation can happen.
Before, if we had something in the cache it was because we built it locally so we also have its directory in yabtwork.