### PR TITLE
Move CppGTest runtime support to be through runtime_params

### DIFF
--- a/yabt/buildcontext.py
+++ b/yabt/buildcontext.py
@@ -352,8 +352,8 @@ class BuildContext:
 
     def run_in_buildenv(
             self, buildenv_target_name: str, cmd: list, cmd_env: dict=None,
-            work_dir: str=None, auto_uid: bool=True, runtime: str=None,
-            run_params: list=None, **kwargs):
+            work_dir: str=None, auto_uid: bool=True, run_params: list=None,
+            **kwargs):
         """Run a command in a named BuildEnv Docker image.
 
         :param buildenv_target_name: A named Docker image target in which the
@@ -385,10 +385,6 @@ class BuildContext:
         container_work_dir = PurePath('/project')
         if work_dir:
             container_work_dir /= work_dir
-        if runtime:
-            docker_run.extend([
-                '--runtime', runtime,
-            ])
 
         docker_run.extend([
             '--rm',

--- a/yabt/builders/cpp.py
+++ b/yabt/builders/cpp.py
@@ -31,6 +31,7 @@ from os.path import basename, dirname, join, relpath, splitext
 
 from ostrich.utils.collections import listify
 
+from yabt.docker import extend_runtime_params, format_docker_run_params
 from ..artifact import ArtifactType as AT
 from .dockerapp import build_app_docker_and_bin, register_app_builder_sig
 from ..extend import (
@@ -190,7 +191,6 @@ register_builder_sig(
     CPP_SIG + [
         ('test_flags', PT.StrList, None),  # flags to append to test command
         ('test_env', None),  # env vars to inject in test process
-        ('runtime', PT.str, None),
         # TODO: support different testenv image for test execution
         # ('in_testenv', PT.Target, None),
     ]
@@ -367,12 +367,14 @@ def cpp_gtest_tester(build_context, target):
     test_cmd = [join(buildenv_workspace, *split(target.name))]
     # take gtest exec flags from the target & from project config
     test_cmd.extend(target.props.test_flags)
+    run_params = extend_runtime_params(
+                target.props.runtime_params,
+                build_context.walk_target_deps_topological_order(target),
+                build_context.conf.runtime_params, True)
     build_context.run_in_buildenv(
         # TODO: target.props.in_testenv,
         target.props.in_buildenv, test_cmd, target.props.test_env,
-        runtime=target.props.runtime
-    )
-
+        run_params=format_docker_run_params(run_params))
 
 register_builder_sig('CppLib', CPP_SIG)
 

--- a/yabt/docker.py
+++ b/yabt/docker.py
@@ -55,7 +55,8 @@ logger = make_logger(__name__)
 
 KNOWN_RUNTIME_PARAMS = frozenset((
         'ports', 'volumes', 'container_name', 'daemonize', 'interactive',
-        'term', 'auto_it', 'rm', 'env', 'work_dir', 'impersonate', 'network'))
+        'term', 'auto_it', 'rm', 'env', 'work_dir', 'impersonate', 'network',
+        'runtime'))
 
 
 def make_pip_requirements(pip_requirements: set, pip_req_file_path: str):
@@ -216,6 +217,9 @@ def format_docker_run_params(params: dict):
         param_strings.extend(['-e', '{}="{}"'.format(var, value)])
     if params.get('network'):
         param_strings.extend(['--net', params['network']])
+    if params.get('runtime'):
+        param_strings.extend(['--runtime', params['runtime']])
+
     return param_strings
 
 


### PR DESCRIPTION
Roll back the change in #128 to be consistent with the approach taken in #144 