### PR TITLE
add the .proto file as an artifact

### DIFF
--- a/yabt/artifact.py
+++ b/yabt/artifact.py
@@ -36,6 +36,7 @@ ArtifactType = Enum('ArtifactType', """app
                                        gen_py
                                        gen_cc
                                        gen_h
+                                       proto
                                        custom_installer
                                        docker_image
                                        """)

--- a/yabt/builders/proto.py
+++ b/yabt/builders/proto.py
@@ -115,6 +115,7 @@ def proto_builder(build_context, target):
     # Add generated files to artifacts / generated list
     for src in target.props.sources:
         src_base = join(proto_dir, splitext(src)[0])
+        process_generated(src_base + '.proto', AT.proto)
         if target.props.gen_python:
             process_generated(src_base + '_pb2.py', AT.gen_py)
         if target.props.gen_cpp:


### PR DESCRIPTION
We need this so that after building a proto all of the relevant proto files will be in yabtwork (updated)