### PR TITLE
support generating the proto descriptor in proto builder

### DIFF
--- a/tests/proto/app/YBuild
+++ b/tests/proto/app/YBuild
@@ -40,3 +40,24 @@ PythonTest(
     deps=':hello-py',
     in_testenv='//:proto-python'
 )
+
+Proto(
+    'hello2-proto',
+    in_buildenv='//:proto-builder',
+    sources='hello2/hello2.proto',
+    build_params={
+        'extra_link_flags': '-lprotobuf',
+    }
+)
+
+Proto(
+    'hello1-proto',
+    in_buildenv='//:proto-builder',
+    sources='hello1/hello1.proto',
+    build_params={
+        'extra_link_flags': '-lprotobuf',
+    },
+    deps=':hello2-proto'
+)
+
+ProtoCollector('hello1-collector', deps=':hello1-proto')

--- a/tests/proto/app/hello1/hello1.proto
+++ b/tests/proto/app/hello1/hello1.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package tests;
+
+message Hello1 {
+    string message = 1;
+}

--- a/tests/proto/app/hello2/hello2.proto
+++ b/tests/proto/app/hello2/hello2.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package tests;
+
+message Hello2 {
+    string message = 1;
+}

--- a/yabt/artifact.py
+++ b/yabt/artifact.py
@@ -37,6 +37,7 @@ ArtifactType = Enum('ArtifactType', """app
                                        gen_cc
                                        gen_h
                                        proto
+                                       proto_descriptor
                                        custom_installer
                                        docker_image
                                        """)

--- a/yabt/builders/proto.py
+++ b/yabt/builders/proto.py
@@ -94,8 +94,8 @@ def proto_builder(build_context, target):
     if target.props.gen_python_rpcz:
         protoc_cmd.extend(('--python_rpcz_out', buildenv_workspace))
     if target.props.gen_descriptor:
-        protoc_cmd.extend(('--descriptor_set_out', join(buildenv_workspace,
-                                                        'descriptor.pb')))
+        protoc_cmd.extend(('--include_imports', '--descriptor_set_out',
+                           join(buildenv_workspace, 'descriptor.pb')))
     protoc_cmd.extend((PurePath(buildenv_workspace) / 'proto' / src).as_posix()
                       for src in target.props.sources)
     build_context.run_in_buildenv(

--- a/yabt/builders/proto.py
+++ b/yabt/builders/proto.py
@@ -183,6 +183,13 @@ def proto_manipulate_target(build_context, target):
 
 @register_build_func('ProtoCollector')
 def proto_collector_builder(build_context, target):
+    """
+    Collect all the .proto files that this target depend on to a directory
+    under yabtwork/*/ProtoCollector.
+    If this target depends on a proto target, then all the .proto files needed
+    for building this proto will get to this directory.
+    TODO(Dana): Support not building the proto (we only need the .proto files)
+    """
     workspace_dir = build_context.get_workspace('ProtoCollector', target.name)
     for dep in build_context.generate_all_deps(target):
         artifact_map = dep.artifacts.get(AT.proto)

--- a/yabt/builders/proto.py
+++ b/yabt/builders/proto.py
@@ -51,6 +51,7 @@ register_builder_sig(
      ('gen_cpp_rpcz', PT.bool, False),
      ('gen_python_grpc', PT.bool, False),
      ('gen_cpp_grpc', PT.bool, False),
+     ('gen_descriptor', PT.bool, False),
      ('grpc_plugin_path', PT.str, '/usr/local/bin/grpc_cpp_plugin'),
      ('copy_generated_to', PT.File, None),
      ('cmd_env', None),
@@ -91,6 +92,9 @@ def proto_builder(build_context, target):
         protoc_cmd.extend(('--cpp_rpcz_out', buildenv_workspace))
     if target.props.gen_python_rpcz:
         protoc_cmd.extend(('--python_rpcz_out', buildenv_workspace))
+    if target.props.gen_descriptor:
+        protoc_cmd.extend(('--descriptor_set_out', join(buildenv_workspace,
+                                                        'descriptor.pb')))
     protoc_cmd.extend((PurePath(buildenv_workspace) / 'proto' / src).as_posix()
                       for src in target.props.sources)
     build_context.run_in_buildenv(
@@ -131,6 +135,9 @@ def proto_builder(build_context, target):
         if target.props.gen_cpp_grpc:
             process_generated(src_base + '.grpc.pb.cc', AT.gen_cc)
             process_generated(src_base + '.grpc.pb.h', AT.gen_h)
+    if target.props.gen_descriptor:
+        process_generated(join(workspace_dir, 'descriptor.pb'),
+                          AT.proto_descriptor)
 
     # Create __init__.py files in all generated directories with Python files
     if target.props.gen_python or target.props.gen_python_rpcz:

--- a/yabt/builders/proto_test.py
+++ b/yabt/builders/proto_test.py
@@ -27,6 +27,8 @@ from subprocess import PIPE
 
 import pytest
 
+from conftest import reset_parser
+from .. import cli, extend
 from . import proto
 from ..buildcontext import BuildContext
 from ..graph import populate_targets_graph
@@ -77,3 +79,55 @@ def test_proto_cpp_prog(basic_conf):
         stdout=PIPE, stderr=PIPE)
     assert 0 == result.returncode
     assert b'Hello, World!' == result.stdout
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures('in_proto_project')
+def test_proto_collector(basic_conf):
+    build_context = BuildContext(basic_conf)
+    basic_conf.targets = ['app:hello1-collector']
+    populate_targets_graph(build_context, basic_conf)
+    build_context.build_graph()
+    assert_all_proto_files_exist()
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures('in_proto_project')
+def test_proto_collector_build_from_cache():
+    # Create cache
+    reset_parser()
+    conf = cli.init_and_get_conf(['--non-interactive', 'build'])
+    extend.Plugin.load_plugins(conf)
+    build_context = BuildContext(conf)
+    conf.targets = ['app:hello1-collector']
+    populate_targets_graph(build_context, conf)
+    build_context.build_graph()
+
+    # Build from cache
+    shutil.rmtree(join('yabtwork', 'flavor__all__'))
+    build_context2 = BuildContext(conf)
+    populate_targets_graph(build_context2, conf)
+    build_context2.build_graph()
+    assert_all_proto_files_exist()
+
+
+def assert_all_proto_files_exist():
+    assert isdir('yabtwork')
+    assert isdir(join('yabtwork', 'flavor__all__'))
+    assert isdir(join('yabtwork', 'flavor__all__', 'ProtoCollector'))
+    assert isdir(join('yabtwork', 'flavor__all__', 'ProtoCollector',
+                      'app_hello1-collector'))
+    assert isdir(join('yabtwork', 'flavor__all__', 'ProtoCollector',
+                      'app_hello1-collector', 'proto'))
+    assert isdir(join('yabtwork', 'flavor__all__', 'ProtoCollector',
+                      'app_hello1-collector', 'proto', 'app'))
+    assert isdir(join('yabtwork', 'flavor__all__', 'ProtoCollector',
+                      'app_hello1-collector', 'proto', 'app', 'hello1'))
+    assert isfile(join('yabtwork', 'flavor__all__', 'ProtoCollector',
+                       'app_hello1-collector', 'proto', 'app', 'hello1',
+                       'hello1.proto'))
+    assert isdir(join('yabtwork', 'flavor__all__', 'ProtoCollector',
+                      'app_hello1-collector', 'proto', 'app', 'hello2'))
+    assert isfile(join('yabtwork', 'flavor__all__', 'ProtoCollector',
+                       'app_hello1-collector', 'proto', 'app', 'hello2',
+                       'hello2.proto'))

--- a/yabt/target_utils_test.py
+++ b/yabt/target_utils_test.py
@@ -93,7 +93,7 @@ def test_norm_name_unqualified_error():
             'possible ambiguity' in str(excinfo.value))
 
 
-_HELLO_PROG_HASH = '41eb61d311e6b841d71f2230e7e62a94'
+_HELLO_PROG_HASH = 'e1d389cdbbc8f41cc9078a97e7f6d766'
 _PROTO_BUILDER = '2673afde9594dc5212450377dfc16b41'
 _BOTH_HASHES = list(sorted([_HELLO_PROG_HASH, _PROTO_BUILDER]))
 


### PR DESCRIPTION
* support generating the proto descriptor in proto builder
* add a new builder: ProtoCollector - collect all the .proto files to its dir under yabtwork.
This can be used if we want to build the proto not using YBT (for example in the android app)