### PR TITLE
fix build hangs for failure in buildenv target when continue_after_fail is on

### DIFF
--- a/yabt/buildcontext.py
+++ b/yabt/buildcontext.py
@@ -301,10 +301,9 @@ class BuildContext:
                         affected_nodes = get_ancestors(graph_copy, target.name)
                         graph_copy.remove_node(target.name)
                         for affected_node in affected_nodes:
-                            if affected_node in self.skipped_nodes:
-                                continue
                             if graph_copy.has_node(affected_node):
-                                self.skipped_nodes.append(affected_node)
+                                if affected_node not in self.skipped_nodes:
+                                    self.skipped_nodes.append(affected_node)
                                 graph_copy.remove_node(affected_node)
                         if self.conf.continue_after_fail:
                             logger.info('Failed target: {} due to error: {}',


### PR DESCRIPTION
we iterate over the graph to build targets twice:
- once over all buildenv targets
- once over all targets (including buildenv)

In the first iteration, buildenv target 'a' fails, and buildenv target 'b' that depends on it is removed form the buildenv targets graph, and added to the skipped_nodes list.
in the second iteration, target 'a' failes, and target 'b' is already in skipped nodes se we don't take care of it. Which means we don't delete it from the graph (which is a different graph from the first iteration).
So, target 'b' stays in the graph but it is never going to be ready for build because target 'a' failed. This makes the build to hang.

This fix is: don't check if the node is in skipped_nodes before deleting it from the graph, only check if it is in the graph.
The only reason skipped_nodes field exists is to print it at the end of the run.