### PR TITLE
when a target name is not found in the build context, similar suggestions are given

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 argcomplete>=1.1
 colorama>=0.3
 ConfigArgParse>=0.10
-difflib
 GitPython>=1.0
 munch>=2.1
 networkx>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 argcomplete>=1.1
 colorama>=0.3
 ConfigArgParse>=0.10
-difflib>=3.0
+difflib
 GitPython>=1.0
 munch>=2.1
 networkx>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 argcomplete>=1.1
 colorama>=0.3
 ConfigArgParse>=0.10
+difflib>=3.2
 GitPython>=1.0
 munch>=2.1
 networkx>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 argcomplete>=1.1
 colorama>=0.3
 ConfigArgParse>=0.10
-difflib>=3.2
+difflib>=3.0
 GitPython>=1.0
 munch>=2.1
 networkx>=2.0

--- a/tests/errors/typo/YBuild
+++ b/tests/errors/typo/YBuild
@@ -17,3 +17,5 @@ DepTester(
     deps=[':zapi', ':base'],  # <-- typo - wrong dep name
     buildenv='//:builderz'  # <-- typo - wrong buildenv name
 )
+
+DepTester('unsimilar', deps=':xyzxyzxyz')  # <-- typo - wrong dep name

--- a/yabt/graph.py
+++ b/yabt/graph.py
@@ -199,8 +199,8 @@ def raise_unresolved_targets(build_context, conf, unknown_seeds, seed_refs):
                           for target_name in sorted(seed_ref.buildenv_of)))
 
         return '{} (possible misspelling of {}) - {}'.format(
-            seed, difflib.get_close_matches(seed, build_context.targets.keys()),
-            ', '.join(reasons))
+            seed, difflib.get_close_matches(
+                seed, build_context.targets.keys()), ', '.join(reasons))
 
     unresolved_str = '\n'.join(format_unresolved(target_name)
                                for target_name in sorted(unknown_seeds))

--- a/yabt/graph.py
+++ b/yabt/graph.py
@@ -199,7 +199,7 @@ def raise_unresolved_targets(build_context, conf, unknown_seeds, seed_refs):
                           for target_name in sorted(seed_ref.buildenv_of)))
 
         return '{} (possible misspelling of {}) - {}'.format(
-            seed, difflib.get_close_matches(seed, build_context.targets),
+            seed, difflib.get_close_matches(seed, build_context.targets.keys()),
             ', '.join(reasons))
 
     unresolved_str = '\n'.join(format_unresolved(target_name)

--- a/yabt/graph.py
+++ b/yabt/graph.py
@@ -24,6 +24,7 @@ yabt target graph
 from collections import defaultdict
 from os.path import relpath
 
+import difflib
 import networkx
 from networkx.algorithms import dag
 
@@ -197,7 +198,9 @@ def raise_unresolved_targets(build_context, conf, unknown_seeds, seed_refs):
                 ', '.join(format_target(target_name)
                           for target_name in sorted(seed_ref.buildenv_of)))
 
-        return '{} - {}'.format(seed, ', '.join(reasons))
+        return '{} (possible misspelling of {}) - {}'.format(
+            seed, difflib.get_close_matches(seed, build_context.targets),
+            ', '.join(reasons))
 
     unresolved_str = '\n'.join(format_unresolved(target_name)
                                for target_name in sorted(unknown_seeds))

--- a/yabt/graph_test.py
+++ b/yabt/graph_test.py
@@ -284,10 +284,10 @@ def test_dep_name_typo(basic_conf):
         populate_targets_graph(build_context, basic_conf)
     ex_msg = str(excinfo.value)
     assert 'Could not resolve 6 targets' in ex_msg
-    assert (':builderz (possible misspelling of [\':builder\']) - buildenv of' +
-            ' typo:foo') in ex_msg
-    assert ('typo:bar (possible misspelling of [\'typo:base\', \'typo:yapi\',' +
-            ' \'typo:flask\']) - seen on command line') in ex_msg
+    assert (':builderz (possible misspelling of [\':builder\']) - ' +
+            'buildenv of typo:foo') in ex_msg
+    assert ('typo:bar (possible misspelling of [\'typo:base\', \'typo:yapi\'' +
+            ', \'typo:flask\']) - seen on command line') in ex_msg
     assert ('typo:blask (possible misspelling of [\'typo:flask\',' +
             ' \'typo:base\', \'typo:yapi\']) - ' +
             'dependency of typo:yapi') in ex_msg
@@ -296,7 +296,8 @@ def test_dep_name_typo(basic_conf):
             'dependency of typo:base') in ex_msg
     assert ('typo:xyzxyzxyz (possible misspelling of []) - dependency of ' +
             'typo:unsimilar') in ex_msg
-    assert ('typo:zapi (possible misspelling of [\'typo:yapi\', \'typo:base\'' +
+    assert ('typo:zapi (possible misspelling of [\'typo:yapi\', ' +
+            '\'typo:base\'' +
             ', \'typo:flask\']) - dependency of typo:foo') in ex_msg
     # # expecting 6 unresolved targets (so error message will have 7 lines)
     assert 7 == len(ex_msg.split('\n'))

--- a/yabt/graph_test.py
+++ b/yabt/graph_test.py
@@ -283,8 +283,7 @@ def test_dep_name_typo(basic_conf):
     with pytest.raises(ValueError) as excinfo:
         populate_targets_graph(build_context, basic_conf)
     ex_msg = str(excinfo.value)
-    print(ex_msg)
-    assert 'Could not resolve 5 targets' in ex_msg
+    assert 'Could not resolve 6 targets' in ex_msg
     assert (':builderz (possible misspelling of [\':builder\']) - buildenv of' +
             ' typo:foo') in ex_msg
     assert ('typo:bar (possible misspelling of [\'typo:base\', \'typo:yapi\',' +
@@ -295,7 +294,9 @@ def test_dep_name_typo(basic_conf):
     assert ('typo:loggin (possible misspelling of [\'typo:logging\',' +
             ' \'typo:foo\', \'typo:yapi\']) - ' +
             'dependency of typo:base') in ex_msg
+    assert ('typo:xyzxyzxyz (possible misspelling of []) - dependency of ' +
+            'typo:unsimilar') in ex_msg
     assert ('typo:zapi (possible misspelling of [\'typo:yapi\', \'typo:base\'' +
             ', \'typo:flask\']) - dependency of typo:foo') in ex_msg
-    # # expecting 5 unresolved targets (so error message will have 6 lines)
-    assert 6 == len(ex_msg.split('\n'))
+    # # expecting 6 unresolved targets (so error message will have 7 lines)
+    assert 7 == len(ex_msg.split('\n'))

--- a/yabt/graph_test.py
+++ b/yabt/graph_test.py
@@ -283,11 +283,19 @@ def test_dep_name_typo(basic_conf):
     with pytest.raises(ValueError) as excinfo:
         populate_targets_graph(build_context, basic_conf)
     ex_msg = str(excinfo.value)
+    print(ex_msg)
     assert 'Could not resolve 5 targets' in ex_msg
-    assert ':builderz - buildenv of typo:foo' in ex_msg
-    assert 'typo:bar - seen on command line' in ex_msg
-    assert 'typo:blask - dependency of typo:yapi' in ex_msg
-    assert 'typo:loggin - dependency of typo:base' in ex_msg
-    assert 'typo:zapi - dependency of typo:foo' in ex_msg
+    assert (':builderz (possible misspelling of [\':builder\']) - buildenv of' +
+            ' typo:foo') in ex_msg
+    assert ('typo:bar (possible misspelling of [\'typo:base\', \'typo:yapi\',' +
+            ' \'typo:flask\']) - seen on command line') in ex_msg
+    assert ('typo:blask (possible misspelling of [\'typo:flask\',' +
+            ' \'typo:base\', \'typo:yapi\']) - ' +
+            'dependency of typo:yapi') in ex_msg
+    assert ('typo:loggin (possible misspelling of [\'typo:logging\',' +
+            ' \'typo:foo\', \'typo:yapi\']) - ' +
+            'dependency of typo:base') in ex_msg
+    assert ('typo:zapi (possible misspelling of [\'typo:yapi\', \'typo:base\'' +
+            ', \'typo:flask\']) - dependency of typo:foo') in ex_msg
     # # expecting 5 unresolved targets (so error message will have 6 lines)
     assert 6 == len(ex_msg.split('\n'))


### PR DESCRIPTION
Here is an example output:

```
Fatal: Could not resolve 1 target:
ymath:vec4 (possible misspelling of ['ymath:vec3', 'ymath:vec2', 'ymath:typed_vec3']) - dependency of ymath:discs_intersection (in /home/dlehavi/projects/resonai2/ymath/YBuild)

```

This resolves issue 93