### PR TITLE
Make sure cached images are push

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ google-cloud-storage
 scandir>=1.2
 
 # For testing
-pytest>=3.6
+pytest>=4.6
 pytest-cov>=2.6.1
 pytest-pep8>=1.0
 tox>=2.3

--- a/tests/caching/YRoot
+++ b/tests/caching/YRoot
@@ -1,4 +1,5 @@
-from yabt.docker import base_image_caching_behavior
+from yabt.docker import (base_image_caching_behavior,
+                         deployable_caching_behavior)
 
 AptGroup('tools', packages=['autoconf', 'automake', 'curl'])
 
@@ -34,5 +35,15 @@ DockerImage(
     # contains the same deo
     deps=':unzip'
 )
+
+DockerImage(
+    'deploy-image',
+    base_image=':ubuntu',
+    image_caching_behavior=deployable_caching_behavior(
+        conf,
+        remote_image_name='yabt/deploy-image',
+        remote_image_tag='v1')
+)
+
 
 TargetGroup('all-images', deps=[':an-image', ':builder', ':builder-base'])

--- a/yabt/builders/golang.py
+++ b/yabt/builders/golang.py
@@ -34,7 +34,7 @@ from ..artifact import ArtifactType as AT
 from .dockerapp import build_app_docker_and_bin, register_app_builder_sig
 from ..extend import (
     PropType as PT, register_build_func, register_builder_sig,
-    register_manipulate_target_hook)
+    register_manipulate_target_hook, register_test_func)
 from ..logging import make_logger
 from ..target_utils import split
 from ..utils import link_files, link_node, rmtree, yprint
@@ -99,8 +99,13 @@ def go_test_manipulate_target(build_context, target):
     target.buildenv = target.props.in_buildenv
 
 
-@register_build_func('GoTest')
+@register_test_func('GoTest')
 def go_test_builder(build_context, target):
+    """Test a Go test"""
+    go_builder_internal(build_context, target, command='test')
+
+@register_build_func('GoTest')
+def go_build_test_builder(build_context, target):
     """Test a Go test"""
     go_builder_internal(build_context, target, command='test')
 

--- a/yabt/builders/golang.py
+++ b/yabt/builders/golang.py
@@ -34,7 +34,7 @@ from ..artifact import ArtifactType as AT
 from .dockerapp import build_app_docker_and_bin, register_app_builder_sig
 from ..extend import (
     PropType as PT, register_build_func, register_builder_sig,
-    register_manipulate_target_hook, register_test_func)
+    register_manipulate_target_hook)
 from ..logging import make_logger
 from ..target_utils import split
 from ..utils import link_files, link_node, rmtree, yprint
@@ -99,13 +99,8 @@ def go_test_manipulate_target(build_context, target):
     target.buildenv = target.props.in_buildenv
 
 
-@register_test_func('GoTest')
-def go_test_builder(build_context, target):
-    """Test a Go test"""
-    go_builder_internal(build_context, target, command='test')
-
 @register_build_func('GoTest')
-def go_build_test_builder(build_context, target):
+def go_test_builder(build_context, target):
     """Test a Go test"""
     go_builder_internal(build_context, target, command='test')
 

--- a/yabt/caching.py
+++ b/yabt/caching.py
@@ -214,13 +214,13 @@ def load_target_from_cache(target: Target, build_context) -> (bool, bool):
                 try:
                     tag_docker_image(image_id, image_full_name)
                     icb = ImageCachingBehavior(
-                      get_image_name(target),
-                      target.props.image_tag,
-                      target.props.image_caching_behavior)
+                        get_image_name(target),
+                        target.props.image_tag,
+                        target.props.image_caching_behavior)
                     if icb.push_image_after_build:
-                      tag_docker_image(image_id, icb.remote_image)
-                      push_docker_image(icb.remote_image,
-                                        build_context.conf.docker_push_cmd)
+                        tag_docker_image(image_id, icb.remote_image)
+                        push_docker_image(icb.remote_image,
+                                          build_context.conf.docker_push_cmd)
 
                 except:
                     logger.debug('Docker image with ID {} not found locally',


### PR DESCRIPTION
In this PR I force a push on cached docker image targets found in the cache.
A different approach would have been to add to the hash the --push flag and the remote image tag but I didn't find a way to do it.
