### PR TITLE
Link GoTest target main sources to separate directory

### DIFF
--- a/tests/golang/goodbye/YBuild
+++ b/tests/golang/goodbye/YBuild
@@ -1,0 +1,10 @@
+GoProg('goodbye',
+       sources='goodbye_main.go',
+       in_buildenv='//:builder')
+
+GoApp('goodbye-app', base_image='//:scratch', main=':goodbye')
+
+# Example of Go test using TestMain and calling functions from the main func file
+GoTest('goodbye-test',
+       sources=['goodbye_main.go', 'goodbye_test.go'],
+       in_buildenv='//:builder')

--- a/tests/golang/goodbye/goodbye_main.go
+++ b/tests/golang/goodbye/goodbye_main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+  "fmt"
+)
+
+var (
+  name = "no-one"
+)
+
+func initName(newName string) {
+  name = newName
+}
+
+func getName() string {
+  return name
+}
+
+func main() {
+  initName("Bill")
+  fmt.Println("Goodbye,", getName())
+}

--- a/tests/golang/goodbye/goodbye_test.go
+++ b/tests/golang/goodbye/goodbye_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+  "os"
+  "testing"
+
+  "github.com/stretchr/testify/assert"
+)
+
+const (
+  newName = "Sebastian"
+)
+
+func TestMain(m *testing.M) {
+  initName(newName)
+  os.Exit(m.Run())
+}
+
+func TestGoodbyeName(t *testing.T) {
+  assert := assert.New(t)
+  assert.Equal(newName, getName())
+}

--- a/tests/golang/goodbye_lib/YBuild
+++ b/tests/golang/goodbye_lib/YBuild
@@ -1,0 +1,9 @@
+GoPackage('goodbye_lib',
+          sources='goodbye_utils.go',
+          in_buildenv='//:builder')
+
+# Example for test target using more than one source files
+GoTest('goodbye_utils_test',
+       sources=['goodbye_utils_test.go', 'test_utils.go'],
+       in_buildenv='//:builder',
+       deps=':goodbye_lib')

--- a/tests/golang/goodbye_lib/goodbye_utils.go
+++ b/tests/golang/goodbye_lib/goodbye_utils.go
@@ -1,0 +1,13 @@
+package goodbye_lib
+
+var (
+  libName = "Bill"
+)
+
+func GetGoodbyeName() string {
+  return libName
+}
+
+func SetGoodbyeName(newName string) {
+  libName = newName
+}

--- a/tests/golang/goodbye_lib/goodbye_utils_test.go
+++ b/tests/golang/goodbye_lib/goodbye_utils_test.go
@@ -1,0 +1,9 @@
+package goodbye_lib
+
+import (
+  "testing"
+)
+
+func TestGoodbyeUtils(t *testing.T) {
+  runGoodbyeLibTest(t, "Bill", "Sebastian")
+}

--- a/tests/golang/goodbye_lib/test_utils.go
+++ b/tests/golang/goodbye_lib/test_utils.go
@@ -1,0 +1,16 @@
+package goodbye_lib
+
+import (
+  "testing"
+
+  "github.com/stretchr/testify/assert"
+
+  "bar.com/goodbye_lib"
+)
+
+func runGoodbyeLibTest(t *testing.T, prevName, newName string) {
+  assert := assert.New(t)
+  assert.Equal(prevName, goodbye_lib.GetGoodbyeName())
+  goodbye_lib.SetGoodbyeName(newName)
+  assert.Equal(newName, goodbye_lib.GetGoodbyeName())
+}

--- a/yabt/builders/golang.py
+++ b/yabt/builders/golang.py
@@ -214,21 +214,18 @@ def go_builder_internal(build_context, target, command, is_binary=True):
     buildenv_workspace = build_context.conf.host_to_buildenv_path(
         workspace_dir
     )
-    target_sources = target.props.sources
-    files_to_link = list(target.props.sources)
-    if command == 'test':
-        target_sources = []
-        files_to_link = []
-        for src in target.props.sources:
-            workspace_src = join("go_test_main", src)
-            target_file = join(workspace_dir, workspace_src)
-            link_node(join(build_context.conf.project_root, src),
-                      target_file)
-            target_sources.append(workspace_src)
+    target_sources = []
+    for src in target.props.sources:
+        workspace_src = join("src", src)
+        target_file = join(workspace_dir, workspace_src)
+        link_node(join(build_context.conf.project_root, src),
+                  target_file)
+        target_sources.append(workspace_src)
     buildenv_sources = [
         join(buildenv_workspace, src) for src in target_sources
     ]
 
+    files_to_link = []
     for dep in build_context.generate_all_deps(target):
         files_to_link.extend(filter(lambda x: x.endswith('.go'),
                                     dep.props.get('sources', [])))

--- a/yabt/builders/golang.py
+++ b/yabt/builders/golang.py
@@ -214,11 +214,20 @@ def go_builder_internal(build_context, target, command, is_binary=True):
     buildenv_workspace = build_context.conf.host_to_buildenv_path(
         workspace_dir
     )
-    buildenv_sources = [
-        join(buildenv_workspace, src) for src in target.props.sources
-    ]
-
+    target_sources = target.props.sources
     files_to_link = list(target.props.sources)
+    if command == 'test':
+        target_sources = []
+        files_to_link = []
+        for src in target.props.sources:
+            workspace_src = join("go_test_main", src)
+            target_file = join(workspace_dir, workspace_src)
+            link_node(join(build_context.conf.project_root, src),
+                      target_file)
+            target_sources.append(workspace_src)
+    buildenv_sources = [
+        join(buildenv_workspace, src) for src in target_sources
+    ]
 
     for dep in build_context.generate_all_deps(target):
         files_to_link.extend(filter(lambda x: x.endswith('.go'),
@@ -231,7 +240,8 @@ def go_builder_internal(build_context, target, command, is_binary=True):
             link_node(join(build_context.conf.project_root, src),
                       target_file)
 
-    link_files(files_to_link, workspace_dir, None, build_context.conf)
+    if len(files_to_link) > 0:
+        link_files(files_to_link, workspace_dir, None, build_context.conf)
 
     download_cache_dir = build_context.conf.host_to_buildenv_path(
         build_context.conf.get_go_packages_path())

--- a/yabt/builders/golang_test.py
+++ b/yabt/builders/golang_test.py
@@ -62,6 +62,26 @@ def test_golang_test(basic_conf):
 
 
 @pytest.mark.slow
+@pytest.mark.usefixtures('in_golang_project')
+def test_golang_test_multisrc(basic_conf):
+    build_context = BuildContext(basic_conf)
+    target_name = 'goodbye_lib:goodbye_utils_test'
+    basic_conf.targets = [target_name]
+    populate_targets_graph(build_context, basic_conf)
+    build_context.build_graph(run_tests=True)
+
+
+@pytest.mark.slow
+@pytest.mark.usefixtures('in_golang_project')
+def test_golang_test_mainfuncs(basic_conf):
+    build_context = BuildContext(basic_conf)
+    target_name = 'goodbye:goodbye-test'
+    basic_conf.targets = [target_name]
+    populate_targets_graph(build_context, basic_conf)
+    build_context.build_graph(run_tests=True)
+
+
+@pytest.mark.slow
 @pytest.mark.usefixtures('in_proto_project')
 def test_golang_builder_proto(basic_conf):
     build_context = BuildContext(basic_conf)


### PR DESCRIPTION
Found a bug when trying to build a test from more than one file in a Go library (when package is not 'main'), because of import conflicts between the test main and the package it tests. Fixed by linking the GoTest main sources to a separate directory under the build workspace.