### PR TITLE
ybt command of target info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ sudo: required
 
 services:
   - docker
-
-addons:
-  apt:
-    packages:
-      - docker-ce
+before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 language: python
 

--- a/yabt/cli.py
+++ b/yabt/cli.py
@@ -142,7 +142,8 @@ def make_parser(project_config_file: str) -> configargparse.ArgumentParser:
         PARSER.add('--upload-tests-to-global-cache', default=False,
                    action='store_true',
                    help='upload to global cache tests that were run')
-        PARSER.add('cmd', choices=['build', 'dot', 'test', 'tree', 'version', 'info'])
+        PARSER.add('cmd', choices=['build', 'dot', 'test', 'tree', 'version',
+                                   'info'])
         PARSER.add('targets', nargs='*')
     return PARSER
 

--- a/yabt/cli.py
+++ b/yabt/cli.py
@@ -142,7 +142,7 @@ def make_parser(project_config_file: str) -> configargparse.ArgumentParser:
         PARSER.add('--upload-tests-to-global-cache', default=False,
                    action='store_true',
                    help='upload to global cache tests that were run')
-        PARSER.add('cmd', choices=['build', 'dot', 'test', 'tree', 'version'])
+        PARSER.add('cmd', choices=['build', 'dot', 'test', 'tree', 'version', 'info'])
         PARSER.add('targets', nargs='*')
     return PARSER
 

--- a/yabt/docker_test.py
+++ b/yabt/docker_test.py
@@ -107,6 +107,7 @@ def test_generate_needed_lists(basic_conf):
     build_context.build_graph()
     result = build_context.run_in_buildenv(
         ':another-image', ['ls', '/etc/apt/sources.list.d/'],
+        auto_uid=False,
         stdout=PIPE, stderr=PIPE)
     assert 0 == result.returncode
     for file in [

--- a/yabt/docker_test.py
+++ b/yabt/docker_test.py
@@ -106,7 +106,7 @@ def test_generate_needed_lists(basic_conf):
     populate_targets_graph(build_context, basic_conf)
     build_context.build_graph()
     result = build_context.run_in_buildenv(
-        ':another-image', ['echo' 'another-image.list nodesource.list'],
+        ':another-image', ['echo', 'another-image.list nodesource.list'],
         auto_uid=False,
         stdout=PIPE, stderr=PIPE)
     print(result.stdout)

--- a/yabt/docker_test.py
+++ b/yabt/docker_test.py
@@ -105,16 +105,16 @@ def test_generate_needed_lists(basic_conf):
     basic_conf.targets = [':another-image']
     populate_targets_graph(build_context, basic_conf)
     build_context.build_graph()
-    result = build_context.run_in_buildenv(
+    result2 = build_context.run_in_buildenv(
         ':another-image', ['echo', 'another-image.list nodesource.list'],
         auto_uid=False,
         stdout=PIPE, stderr=PIPE)
-    print(result.stdout)
-    resul2 = build_context.run_in_buildenv(
+    print(result2.stdout)
+    result = build_context.run_in_buildenv(
         ':another-image', ['ls', '-l', '/'],
         auto_uid=False,
         stdout=PIPE, stderr=PIPE)
-    print(result2.stdout)
+    print(result.stdout)
     assert 0 == result.returncode
     for file in [
             b'another-image.list',

--- a/yabt/docker_test.py
+++ b/yabt/docker_test.py
@@ -106,22 +106,19 @@ def test_generate_needed_lists(basic_conf):
     populate_targets_graph(build_context, basic_conf)
     build_context.build_graph()
     result = build_context.run_in_buildenv(
+        ':another-image', ['echo' 'another-image.list nodesource.list'],
+        auto_uid=False,
+        stdout=PIPE, stderr=PIPE)
+    print(result.stdout)
+    resul2 = build_context.run_in_buildenv(
         ':another-image', ['ls', '-l', '/'],
         auto_uid=False,
         stdout=PIPE, stderr=PIPE)
-    print(result)
-    result = build_context.run_in_buildenv(
-        ':another-image', ['ls', '-l', '/etc/'],
-        auto_uid=False,
-        stdout=PIPE, stderr=PIPE)
-    print(result)
-    result = build_context.run_in_buildenv(
-        ':another-image', ['ls', '/etc/apt/sources.list.d/'],
-        auto_uid=False,
-        stdout=PIPE, stderr=PIPE)
+    print(result2.stdout)
     assert 0 == result.returncode
     for file in [
             b'another-image.list',
             b'nodesource.list',
             ]:
         assert file in result.stdout
+    print(result)

--- a/yabt/docker_test.py
+++ b/yabt/docker_test.py
@@ -105,20 +105,12 @@ def test_generate_needed_lists(basic_conf):
     basic_conf.targets = [':another-image']
     populate_targets_graph(build_context, basic_conf)
     build_context.build_graph()
-    result2 = build_context.run_in_buildenv(
-        ':another-image', ['echo', 'another-image.list nodesource.list'],
-        auto_uid=False,
-        stdout=PIPE, stderr=PIPE)
-    print(result2.stdout)
     result = build_context.run_in_buildenv(
-        ':another-image', ['ls', '-l', '/'],
-        auto_uid=False,
+        ':another-image', ['ls', '/etc/apt/sources.list.d/'],
         stdout=PIPE, stderr=PIPE)
-    print(result.stdout)
     assert 0 == result.returncode
     for file in [
             b'another-image.list',
             b'nodesource.list',
             ]:
         assert file in result.stdout
-    print(result)

--- a/yabt/docker_test.py
+++ b/yabt/docker_test.py
@@ -106,6 +106,16 @@ def test_generate_needed_lists(basic_conf):
     populate_targets_graph(build_context, basic_conf)
     build_context.build_graph()
     result = build_context.run_in_buildenv(
+        ':another-image', ['ls', '-l', '/'],
+        auto_uid=False,
+        stdout=PIPE, stderr=PIPE)
+    print(result)
+    result = build_context.run_in_buildenv(
+        ':another-image', ['ls', '-l', '/etc/'],
+        auto_uid=False,
+        stdout=PIPE, stderr=PIPE)
+    print(result)
+    result = build_context.run_in_buildenv(
         ':another-image', ['ls', '/etc/apt/sources.list.d/'],
         auto_uid=False,
         stdout=PIPE, stderr=PIPE)

--- a/yabt/target_info.py
+++ b/yabt/target_info.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2021 Resonai Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Gives information about the target
+~~~~~~~~~~~~~~~~~
+
+:author: Dana Shamir
+"""
+
+from .config import Config
+from .docker import get_image_name
+from .logging import make_logger
+from .target_utils import ImageCachingBehavior, parse_target_selectors
+
+
+logger = make_logger(__name__)
+
+
+def print_target_info(conf: Config, build_context):
+  targets = parse_target_selectors(conf.targets, conf)
+  for target_name in targets:
+    target = build_context.targets[target_name]
+    icb = ImageCachingBehavior(get_image_name(target), target.props.image_tag, target.props.image_caching_behavior)
+    logger.info('target: {}, image name: {}'.format(target_name, icb.remote_image))

--- a/yabt/target_info.py
+++ b/yabt/target_info.py
@@ -36,7 +36,9 @@ def print_target_info(conf: Config, build_context):
       'workspace': build_context.get_workspace(target.builder_name, target_name)
     }
     if 'image_caching_behavior' in target.props:
-      info['remote_image_name'] = target.props.image_caching_behavior.get('remote_image_name', None)
-      info['remote_image_tag'] = target.props.image_caching_behavior.get('remote_image_tag', None)
+      if 'remote_image_name' in target.props.image_caching_behavior:
+        info['remote_image_name'] = target.props.image_caching_behavior['remote_image_name']
+      if 'remote_image_tag' in target.props.image_caching_behavior:
+        info['remote_image_tag'] = target.props.image_caching_behavior['remote_image_tag']
     targets_info[target_name] = info
   print(json.dumps(targets_info))

--- a/yabt/target_info.py
+++ b/yabt/target_info.py
@@ -24,9 +24,8 @@ Gives information about the target
 import json
 
 from .config import Config
-from .docker import get_image_name
 from .logging import make_logger
-from .target_utils import ImageCachingBehavior, parse_target_selectors
+from .target_utils import parse_target_selectors
 
 
 logger = make_logger(__name__)
@@ -37,10 +36,11 @@ def print_target_info(conf: Config, build_context):
   targets_info = {}
   for target_name in targets:
     target = build_context.targets[target_name]
-    targets_info[target_name] = {
-      'image_name': get_image_name(target),
-      'image_tag': target.props.image_tag,
-      'remote_image_name': target.props.image_caching_behavior.get('remote_image_name', None),
-      'remote_image_tag': target.props.image_caching_behavior.get('remote_image_tag', None)
+    info = {
+      'workspace': build_context.get_workspace(target.builder_name, target_name)
     }
+    if 'image_caching_behavior' in target.props:
+      info['remote_image_name'] = target.props.image_caching_behavior.get('remote_image_name', None)
+      info['remote_image_tag'] = target.props.image_caching_behavior.get('remote_image_tag', None)
+    targets_info[target_name] = info
   print(json.dumps(targets_info))

--- a/yabt/target_info.py
+++ b/yabt/target_info.py
@@ -27,7 +27,7 @@ from .config import Config
 from .target_utils import parse_target_selectors
 
 
-def print_target_info(conf: Config, build_context):
+def get_target_info_json(conf: Config, build_context):
     targets = parse_target_selectors(conf.targets, conf)
     targets_info = {}
     for target_name in targets:
@@ -44,4 +44,4 @@ def print_target_info(conf: Config, build_context):
                 info['remote_image_tag'] = \
                     target.props.image_caching_behavior['remote_image_tag']
         targets_info[target_name] = info
-    print(json.dumps(targets_info))
+    return json.dumps(targets_info)

--- a/yabt/target_info.py
+++ b/yabt/target_info.py
@@ -21,6 +21,8 @@ Gives information about the target
 :author: Dana Shamir
 """
 
+import json
+
 from .config import Config
 from .docker import get_image_name
 from .logging import make_logger
@@ -32,7 +34,13 @@ logger = make_logger(__name__)
 
 def print_target_info(conf: Config, build_context):
   targets = parse_target_selectors(conf.targets, conf)
+  targets_info = {}
   for target_name in targets:
     target = build_context.targets[target_name]
-    icb = ImageCachingBehavior(get_image_name(target), target.props.image_tag, target.props.image_caching_behavior)
-    logger.info('target: {}, image name: {}'.format(target_name, icb.remote_image))
+    targets_info[target_name] = {
+      'image_name': get_image_name(target),
+      'image_tag': target.props.image_tag,
+      'remote_image_name': target.props.image_caching_behavior.get('remote_image_name', None),
+      'remote_image_tag': target.props.image_caching_behavior.get('remote_image_tag', None)
+    }
+  print(json.dumps(targets_info))

--- a/yabt/target_info.py
+++ b/yabt/target_info.py
@@ -28,17 +28,20 @@ from .target_utils import parse_target_selectors
 
 
 def print_target_info(conf: Config, build_context):
-  targets = parse_target_selectors(conf.targets, conf)
-  targets_info = {}
-  for target_name in targets:
-    target = build_context.targets[target_name]
-    info = {
-      'workspace': build_context.get_workspace(target.builder_name, target_name)
-    }
-    if 'image_caching_behavior' in target.props:
-      if 'remote_image_name' in target.props.image_caching_behavior:
-        info['remote_image_name'] = target.props.image_caching_behavior['remote_image_name']
-      if 'remote_image_tag' in target.props.image_caching_behavior:
-        info['remote_image_tag'] = target.props.image_caching_behavior['remote_image_tag']
-    targets_info[target_name] = info
-  print(json.dumps(targets_info))
+    targets = parse_target_selectors(conf.targets, conf)
+    targets_info = {}
+    for target_name in targets:
+        target = build_context.targets[target_name]
+        info = {
+            'workspace': build_context.get_workspace(target.builder_name,
+                                                     target_name)
+        }
+        if 'image_caching_behavior' in target.props:
+            if 'remote_image_name' in target.props.image_caching_behavior:
+                info['remote_image_name'] = \
+                    target.props.image_caching_behavior['remote_image_name']
+            if 'remote_image_tag' in target.props.image_caching_behavior:
+                info['remote_image_tag'] = \
+                    target.props.image_caching_behavior['remote_image_tag']
+        targets_info[target_name] = info
+    print(json.dumps(targets_info))

--- a/yabt/target_info.py
+++ b/yabt/target_info.py
@@ -24,11 +24,7 @@ Gives information about the target
 import json
 
 from .config import Config
-from .logging import make_logger
 from .target_utils import parse_target_selectors
-
-
-logger = make_logger(__name__)
 
 
 def print_target_info(conf: Config, build_context):

--- a/yabt/target_info_test.py
+++ b/yabt/target_info_test.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2021 Resonai Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+yabt target info tests
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:author: Dana Shamir
+"""
+import json
+import os
+import pytest
+
+from .buildcontext import BuildContext
+from .graph import populate_targets_graph
+from .target_info import get_target_info_json
+
+
+@pytest.mark.usefixtures('in_caching_project')
+def test_target_info(basic_conf):
+    basic_conf.targets = [':builder-base', ':builder']
+    build_context = BuildContext(basic_conf)
+    populate_targets_graph(build_context, basic_conf)
+    result = get_target_info_json(basic_conf, build_context)
+    expected = {
+        ':builder-base':
+            {'workspace': os.path.join(
+                os.getcwd(), 'yabtwork', 'flavor__all__', 'DockerImage',
+                '_builder-base'),
+             'remote_image_name': 'itamarost/builder-base-test',
+             'remote_image_tag': 'v1'},
+        ':builder':
+            {'workspace': os.path.join(
+                os.getcwd(), 'yabtwork', 'flavor__all__', 'DockerImage',
+                '_builder')}
+    }
+    assert json.loads(result) == expected

--- a/yabt/yabt.py
+++ b/yabt/yabt.py
@@ -34,7 +34,8 @@ from .extend import Plugin
 from .graph import populate_targets_graph
 from .dot import write_dot
 from .logging import make_logger
-from .target_utils import parse_target_selectors, split, Target
+from .target_info import print_target_info
+from .target_utils import parse_target_selectors, split
 from .utils import fatal
 
 
@@ -101,6 +102,12 @@ def cmd_dot(conf: Config):
             write_dot(build_context, conf, out_file)
 
 
+def cmd_info(conf: Config):
+    build_context = BuildContext(conf)
+    populate_targets_graph(build_context, conf)
+    print_target_info(conf, build_context)
+
+
 def cmd_tree(conf: Config):
     """Print out a neat targets dependency tree based on requested targets."""
     build_context = BuildContext(conf)
@@ -136,6 +143,7 @@ def main():
         'dot': YabtCommand(func=cmd_dot, requires_project=True),
         'test': YabtCommand(func=cmd_test, requires_project=True),
         'tree': YabtCommand(func=cmd_tree, requires_project=True),
+        'info': YabtCommand(func=cmd_info, requires_project=True),
         'version': YabtCommand(func=cmd_version, requires_project=False),
         'list-builders': YabtCommand(func=cmd_list, requires_project=False),
     }

--- a/yabt/yabt.py
+++ b/yabt/yabt.py
@@ -34,7 +34,7 @@ from .extend import Plugin
 from .graph import populate_targets_graph
 from .dot import write_dot
 from .logging import make_logger
-from .target_info import print_target_info
+from .target_info import get_target_info_json
 from .target_utils import parse_target_selectors, split
 from .utils import fatal
 
@@ -105,7 +105,7 @@ def cmd_dot(conf: Config):
 def cmd_info(conf: Config):
     build_context = BuildContext(conf)
     populate_targets_graph(build_context, conf)
-    print_target_info(conf, build_context)
+    print(get_target_info_json(conf, build_context))
 
 
 def cmd_tree(conf: Config):


### PR DESCRIPTION
Add a ybt command that prints information about the target as json. Currently remote_image_name, remote_image_tag, workspace.

Run example:
`ybt info registration/services:frame_recorder_service yio:cprint_pb ymath:ymath_types`
Output:
`{"registration/services:frame_recorder_service": {"workspace": "/Users/dana/work/resonai2/yabtwork/release_flavor/GoApp/registration_services_frame_recorder_service", "remote_image_name": "localhost:5000/yowza3d/frame_recorder_service", "remote_image_tag": "dca2c0eb290c3ffa0db94a6a4f1c8fab3596c989"}, "yio:cprint_pb": {"workspace": "/Users/dana/work/resonai2/yabtwork/release_flavor/CppApp/yio_cprint_pb", "remote_image_name": null, "remote_image_tag": null}, "ymath:ymath_types": {"workspace": "/Users/dana/work/resonai2/yabtwork/release_flavor/CppLib/ymath_ymath_types"}}`