### PR TITLE
change the directory we write the generated protos to

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ google-cloud-storage
 scandir>=1.2
 
 # For testing
+# pinning flake due to: https://github.com/PyCQA/flake8/issues/1419
+flake8<4
 pytest>=4.6
 pytest-cov>=2.6.1
 pytest-flake8>=1.0

--- a/tests/proto/YSettings
+++ b/tests/proto/YSettings
@@ -1,4 +1,5 @@
 def get_common_config(config, args):
     return {
         'go_module': 'foo.com',
+        'proto_gen_dir': 'ybtproto',
     }

--- a/tests/proto/app/hello.cc
+++ b/tests/proto/app/hello.cc
@@ -1,7 +1,7 @@
 #include <fstream>
 #include <iostream>
 
-#include "proto/app/hello.pb.h"
+#include "ybtproto/app/hello.pb.h"
 
 int main(int argc, char* argv[]) {
     // Verify that the version of the library that we linked against is

--- a/tests/proto/app/hello.go
+++ b/tests/proto/app/hello.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/golang/protobuf/proto"
-	pb "foo.com/proto/app"
+	pb "foo.com/ybtproto/app"
 )
 
 func main() {

--- a/tests/proto/app/hello.py
+++ b/tests/proto/app/hello.py
@@ -1,4 +1,4 @@
-from proto.app.hello_pb2 import Hello
+from ybtproto.app.hello_pb2 import Hello
 
 
 def get_message(msg_file):

--- a/yabt/builders/proto.py
+++ b/yabt/builders/proto.py
@@ -83,7 +83,8 @@ def proto_builder(build_context, target):
     buildenv_workspace = build_context.conf.host_to_buildenv_path(
         workspace_dir)
     protoc_cmd = target.props.proto_cmd + ['--proto_path', buildenv_workspace]
-    descriptor_path = join(PROTO_GEN_DIR, get_safe_path(target.name.lstrip(':')) +
+    descriptor_path = join(PROTO_GEN_DIR,
+                           get_safe_path(target.name.lstrip(':')) +
                            '_descriptor.pb')
     if target.props.gen_cpp:
         protoc_cmd.extend(('--cpp_out', buildenv_workspace))
@@ -113,8 +114,9 @@ def proto_builder(build_context, target):
         protoc_cmd.extend(
             ('--include_imports', '--descriptor_set_out',
              (PurePath(buildenv_workspace) / descriptor_path).as_posix()))
-    protoc_cmd.extend((PurePath(buildenv_workspace) / PROTO_GEN_DIR / src).as_posix()
-                      for src in target.props.sources)
+    protoc_cmd.extend(
+      (PurePath(buildenv_workspace) / PROTO_GEN_DIR / src).as_posix()
+      for src in target.props.sources)
     build_context.run_in_buildenv(
         target.props.in_buildenv, protoc_cmd, target.props.cmd_env)
     generated_files = []

--- a/yabt/builders/proto.py
+++ b/yabt/builders/proto.py
@@ -40,6 +40,8 @@ from ..utils import link_files, rmtree, yprint, link_node
 logger = make_logger(__name__)
 
 
+PROTO_GEN_DIR = 'ybtproto'
+
 register_builder_sig(
     'Proto',
     [('sources', PT.FileList),
@@ -68,7 +70,7 @@ def proto_builder(build_context, target):
     workspace_dir = build_context.get_workspace('ProtoBuilder', target.name)
     # make sure workdir is clean
     rmtree(workspace_dir)
-    proto_dir = join(workspace_dir, 'proto')
+    proto_dir = join(workspace_dir, PROTO_GEN_DIR)
     # Collect proto sources from this target and all dependecies,
     # to link under the target sandbox dir
     protos = [source for source in target.props.sources
@@ -81,7 +83,7 @@ def proto_builder(build_context, target):
     buildenv_workspace = build_context.conf.host_to_buildenv_path(
         workspace_dir)
     protoc_cmd = target.props.proto_cmd + ['--proto_path', buildenv_workspace]
-    descriptor_path = join('proto', get_safe_path(target.name.lstrip(':')) +
+    descriptor_path = join(PROTO_GEN_DIR, get_safe_path(target.name.lstrip(':')) +
                            '_descriptor.pb')
     if target.props.gen_cpp:
         protoc_cmd.extend(('--cpp_out', buildenv_workspace))
@@ -111,7 +113,7 @@ def proto_builder(build_context, target):
         protoc_cmd.extend(
             ('--include_imports', '--descriptor_set_out',
              (PurePath(buildenv_workspace) / descriptor_path).as_posix()))
-    protoc_cmd.extend((PurePath(buildenv_workspace) / 'proto' / src).as_posix()
+    protoc_cmd.extend((PurePath(buildenv_workspace) / PROTO_GEN_DIR / src).as_posix()
                       for src in target.props.sources)
     build_context.run_in_buildenv(
         target.props.in_buildenv, protoc_cmd, target.props.cmd_env)

--- a/yabt/builders/proto_test.py
+++ b/yabt/builders/proto_test.py
@@ -33,7 +33,7 @@ from . import proto
 from ..buildcontext import BuildContext
 from ..graph import populate_targets_graph
 from ..utils import yprint
-
+from .proto import PROTO_GEN_DIR
 
 def clear_output():
     try:
@@ -52,16 +52,16 @@ def test_proto_builder(basic_conf):
     build_context.build_graph()
     assert isdir('build')
     assert isdir(join('build', 'gen'))
-    assert isdir(join('build', 'gen', 'proto'))
-    assert isfile(join('build', 'gen', 'proto', '__init__.py'))
-    assert isdir(join('build', 'gen', 'proto', 'app'))
-    assert isfile(join('build', 'gen', 'proto', 'app', '__init__.py'))
+    assert isdir(join('build', 'gen', PROTO_GEN_DIR))
+    assert isfile(join('build', 'gen', PROTO_GEN_DIR, '__init__.py'))
+    assert isdir(join('build', 'gen', PROTO_GEN_DIR, 'app'))
+    assert isfile(join('build', 'gen', PROTO_GEN_DIR, 'app', '__init__.py'))
     for exp_gen_fname in [
         'hello.pb.cc',
         'hello.pb.h',
         'hello_pb2.py'
     ]:
-        assert isfile(join('build', 'gen', 'proto', 'app', exp_gen_fname))
+        assert isfile(join('build', 'gen', PROTO_GEN_DIR, 'app', exp_gen_fname))
     clear_output()
 
 
@@ -118,16 +118,16 @@ def assert_all_proto_files_exist():
     assert isdir(join('yabtwork', 'flavor__all__', 'ProtoCollector',
                       'app_hello1-collector'))
     assert isdir(join('yabtwork', 'flavor__all__', 'ProtoCollector',
-                      'app_hello1-collector', 'proto'))
+                      'app_hello1-collector', PROTO_GEN_DIR))
     assert isdir(join('yabtwork', 'flavor__all__', 'ProtoCollector',
-                      'app_hello1-collector', 'proto', 'app'))
+                      'app_hello1-collector', PROTO_GEN_DIR, 'app'))
     assert isdir(join('yabtwork', 'flavor__all__', 'ProtoCollector',
-                      'app_hello1-collector', 'proto', 'app', 'hello1'))
+                      'app_hello1-collector', PROTO_GEN_DIR, 'app', 'hello1'))
     assert isfile(join('yabtwork', 'flavor__all__', 'ProtoCollector',
-                       'app_hello1-collector', 'proto', 'app', 'hello1',
+                       'app_hello1-collector', PROTO_GEN_DIR, 'app', 'hello1',
                        'hello1.proto'))
     assert isdir(join('yabtwork', 'flavor__all__', 'ProtoCollector',
-                      'app_hello1-collector', 'proto', 'app', 'hello2'))
+                      'app_hello1-collector', PROTO_GEN_DIR, 'app', 'hello2'))
     assert isfile(join('yabtwork', 'flavor__all__', 'ProtoCollector',
-                       'app_hello1-collector', 'proto', 'app', 'hello2',
+                       'app_hello1-collector', PROTO_GEN_DIR, 'app', 'hello2',
                        'hello2.proto'))

--- a/yabt/builders/proto_test.py
+++ b/yabt/builders/proto_test.py
@@ -33,7 +33,9 @@ from . import proto
 from ..buildcontext import BuildContext
 from ..graph import populate_targets_graph
 from ..utils import yprint
-from .proto import PROTO_GEN_DIR
+
+
+PROTO_GEN_DIR = 'ybtproto'  # as defined in tests/proto/YSettings
 
 
 def clear_output():

--- a/yabt/builders/proto_test.py
+++ b/yabt/builders/proto_test.py
@@ -35,6 +35,7 @@ from ..graph import populate_targets_graph
 from ..utils import yprint
 from .proto import PROTO_GEN_DIR
 
+
 def clear_output():
     try:
         shutil.rmtree('build')
@@ -61,7 +62,8 @@ def test_proto_builder(basic_conf):
         'hello.pb.h',
         'hello_pb2.py'
     ]:
-        assert isfile(join('build', 'gen', PROTO_GEN_DIR, 'app', exp_gen_fname))
+        assert isfile(
+          join('build', 'gen', PROTO_GEN_DIR, 'app', exp_gen_fname))
     clear_output()
 
 

--- a/yabt/target_utils_test.py
+++ b/yabt/target_utils_test.py
@@ -93,7 +93,7 @@ def test_norm_name_unqualified_error():
             'possible ambiguity' in str(excinfo.value))
 
 
-_HELLO_PROG_HASH = '9cf98ea1d931fea076d1ea45a87d3946'
+_HELLO_PROG_HASH = '52aea5f9d27f92cf9137debf6b378fd2'
 _PROTO_BUILDER = 'a066abe4da520fd51119e167bcd964aa'
 _BOTH_HASHES = list(sorted([_HELLO_PROG_HASH, _PROTO_BUILDER]))
 


### PR DESCRIPTION
Allow controlling of the directory in which the proto builder place the generated files.
The default is still "proto" so it does not breaks current repositories.

The reason is to provide a way to go around issues in python when there is a package named "proto", specifically "proto-plus" which is used by many google cloud packages:
https://github.com/googleapis/proto-plus-python/issues/79 

 