### PR TITLE
Fixing pytest tester to include context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
+  - "3.10"
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
-  - "3.10"
 
 # command to install dependencies
 install:

--- a/yabt/builders/python.py
+++ b/yabt/builders/python.py
@@ -135,7 +135,10 @@ def pythontest_tester(build_context, target):
     """Run a Python test"""
     yprint(build_context.conf, 'Run PythonTest', target)
     workspace_dir = build_context.get_workspace('PythonTest', target.name)
-    gen_dir = join(workspace_dir, 'gen')
+    buildenv_workspace = build_context.conf.host_to_buildenv_path(
+      workspace_dir)
+
+    gen_dir = join(buildenv_workspace, 'gen')
 
     # Run the test module
     test_env = target.props.test_env or {}
@@ -143,7 +146,7 @@ def pythontest_tester(build_context, target):
     pypath.append(relpath(gen_dir, build_context.conf.project_root))
     test_env['PYTHONPATH'] = ':'.join(pypath)
     test_env['BIN_DIR'] = build_context.conf.host_to_buildenv_path(
-        join(workspace_dir, 'bin'))
+        join(buildenv_workspace, 'bin'))
     run_params = extend_runtime_params(
         target.props.runtime_params,
         build_context.walk_target_deps_topological_order(target),


### PR DESCRIPTION
As @eyal-resonai  pointed out - we must use host_to_buildenv_path for PythoTest, now that it has a builder; all the other builders have it, and it even has a test (see yabt/builders/proto_test.py )