### PR TITLE
rollback python test link in build

### DIFF
--- a/yabt/builders/python.py
+++ b/yabt/builders/python.py
@@ -119,6 +119,12 @@ def pythontest_manipulate_target(build_context, target):
 @register_build_func('PythonTest')
 def pythontest_builder(build_context, target):
     yprint(build_context.conf, 'Build PythonTest', target)
+
+
+@register_test_func('PythonTest')
+def pythontest_tester(build_context, target):
+    """Run a Python test"""
+    yprint(build_context.conf, 'Run PythonTest', target)
     workspace_dir = build_context.get_workspace('PythonTest', target.name)
 
     # Link generated Python protos & required binaries
@@ -129,24 +135,13 @@ def pythontest_builder(build_context, target):
             workspace_dir, [AT.gen_py, AT.binary, AT.proto_descriptor],
             build_context.conf)
 
-
-@register_test_func('PythonTest')
-def pythontest_tester(build_context, target):
-    """Run a Python test"""
-    yprint(build_context.conf, 'Run PythonTest', target)
-    workspace_dir = build_context.get_workspace('PythonTest', target.name)
-    buildenv_workspace = build_context.conf.host_to_buildenv_path(
-      workspace_dir)
-
-    gen_dir = join(buildenv_workspace, 'gen')
-
     # Run the test module
     test_env = target.props.test_env or {}
     pypath = test_env.get('PYTHONPATH', '.').split(':')
     pypath.append(relpath(gen_dir, build_context.conf.project_root))
     test_env['PYTHONPATH'] = ':'.join(pypath)
     test_env['BIN_DIR'] = build_context.conf.host_to_buildenv_path(
-        join(buildenv_workspace, 'bin'))
+        join(workspace_dir, 'bin'))
     run_params = extend_runtime_params(
         target.props.runtime_params,
         build_context.walk_target_deps_topological_order(target),


### PR DESCRIPTION
revert "move the linking of all the relevant files to the python test target directory to run on build and not on test".

The reason - this code isn't packed in any artifact, and therefore when we load the target from the cache (specifically it's only relevant when loading from the **global** cache) we don't load this part, meaning the needed files aren't linked to the right place and we get an error when trying to run the test.

@shirl-resonai, @amirbennatan - sorry, it isn't as easy as I thought...