### PR TITLE
Retain go.mod and go.sum between builds

### DIFF
--- a/tests/pkgmgrs/YRoot
+++ b/tests/pkgmgrs/YRoot
@@ -107,7 +107,7 @@ DockerImage(
 AptRepository(
     'gcloud-repository',
     source='deb http://packages.cloud.google.com/apt cloud-sdk-stretch main',
-    key='8B57C5C2836F4BEB'
+    key='B53DC80D13EDEF05'
 )
 
 AptPackage(

--- a/yabt/builders/golang.py
+++ b/yabt/builders/golang.py
@@ -151,9 +151,9 @@ def go_test_tester(build_context, target):
         run_params=format_docker_run_params(run_params))
 
 
-def rm_all_but_go_mod(workspace_dir):
+def rm_all_but_go_mod_and_sum(workspace_dir):
     for fname in listdir(workspace_dir):
-        if fname == 'go.mod':
+        if fname in ['go.mod', 'go.sum']:
             continue
         filepath = join(workspace_dir, fname)
         if isfile(filepath):
@@ -215,7 +215,7 @@ def go_builder_internal(build_context, target, command, is_binary=True):
         ))
 
     workspace_dir = build_context.get_workspace(builder_name, target.name)
-    rmtree(workspace_dir)
+    rm_all_but_go_mod_and_sum(workspace_dir)
 
     buildenv_workspace = build_context.conf.host_to_buildenv_path(
         workspace_dir


### PR DESCRIPTION
I think it worked that way in the past, but a while back we stopped using this function that skips go.mod and go.sum when clearing the workspace.
These two files serve the golang build system, and help it cache packages and not download them from scratch every time.