### PR TITLE
Always run go mod tidy

### DIFF
--- a/yabt/builders/golang.py
+++ b/yabt/builders/golang.py
@@ -280,6 +280,7 @@ def go_builder_internal(build_context, target, command, is_binary=True):
             build_cmd_env,
             work_dir=buildenv_workspace
         )
+    # always run go mod tidy
     build_context.run_in_buildenv(
         target.props.in_buildenv,
         ['go', 'mod', 'tidy'],

--- a/yabt/builders/golang.py
+++ b/yabt/builders/golang.py
@@ -280,12 +280,12 @@ def go_builder_internal(build_context, target, command, is_binary=True):
             build_cmd_env,
             work_dir=buildenv_workspace
         )
-        build_context.run_in_buildenv(
-            target.props.in_buildenv,
-            ['go', 'mod', 'tidy'],
-            build_cmd_env,
-            work_dir=buildenv_workspace
-        )
+    build_context.run_in_buildenv(
+        target.props.in_buildenv,
+        ['go', 'mod', 'tidy'],
+        build_cmd_env,
+        work_dir=buildenv_workspace
+    )
 
     if len(buildenv_sources) > 0:
         binary = join(*split(target.name)) if is_binary else None


### PR DESCRIPTION
Go mod tidy should always be run, since it examines the dependencies and downloads missing packages (the previous fix was that so that we don't download all of them every time, this fix is so that we **do** download the ones we need).