### PR TITLE
Support running clang tidy as part of the build process

### DIFF
--- a/yabt/builders/cpp.py
+++ b/yabt/builders/cpp.py
@@ -28,6 +28,7 @@ TODO: CppSharedLib builder
 
 
 from hashlib import md5
+import json
 from os.path import basename, dirname, join, relpath, splitext
 
 from ostrich.utils.collections import listify
@@ -77,11 +78,17 @@ class CompilerConfig:
             'compile_flags', build_context.conf, target, []))
         self.link_flags = list(self.get(
             'link_flags', build_context.conf, target, []))
+        self.clang_tidy = self.get(
+            'clang_tidy', build_context.conf, target, 'clang-tidy')
+        self.clang_tidy_config = self.get(
+            'clang_tidy_config', build_context.conf, target, 'clang_tidy.conf')
         self.include_path = list(self.get(
             'include_path', build_context.conf, target, []))
 
         self.use_fdebug_prefix_map_flag = \
             build_context.conf.use_fdebug_prefix_map_flag
+        self.run_clang_tidy = \
+            build_context.conf.run_clang_tidy
 
         def generate_extra_params():
             if extra_params:
@@ -252,6 +259,11 @@ def compile_cc(build_context, compiler_config, buildenv, sources,
        and return list of generated object file.
     """
     objects = []
+    compile_commands = []
+    buildenv_path_to_compile_commands = join(buildenv_workspace,
+                                             'compile_commands.json')
+    host_path_to_compile_commands = join(workspace_dir,
+                                         'compile_commands.json')
     for src in sources:
         obj_rel_path = '{}.o'.format(splitext(src)[0])
         obj_file = join(buildenv_workspace, obj_rel_path)
@@ -260,21 +272,37 @@ def compile_cc(build_context, compiler_config, buildenv, sources,
         if compiler_config.use_fdebug_prefix_map_flag:
             # Store relative paths (instead of absolute) in debugger symbols
             # when in debug mode (with gcc and clang, it is harmless otherwise)
-            special_flags.extend(['-fdebug-prefix-map=%s=.' %
-                                  buildenv_workspace])
-
-        compile_cmd = (
-            [compiler_config.compiler, '-o', obj_file, '-c'] +
-            compiler_config.compile_flags +
-            ['-I{}'.format(path) for path in include_paths] +
-            special_flags +
-            [join(buildenv_workspace, src)])
+            special_flags.extend(
+                ['-fdebug-prefix-map=%s=.' % buildenv_workspace])
+        if compiler_config.run_clang_tidy:
+            special_flags.append('-MJ%s' % buildenv_path_to_compile_commands)
+        compile_cmd = ([compiler_config.compiler, '-o', obj_file, '-c'] +
+                       compiler_config.compile_flags +
+                       ['-I{}'.format(path) for path in include_paths] +
+                       special_flags + [join(buildenv_workspace, src)])
         # TODO: capture and transform error messages from compiler so file
         # paths match host paths for smooth(er) editor / IDE integration
         build_context.run_in_buildenv(buildenv, compile_cmd, cmd_env)
+        if compiler_config.run_clang_tidy:
+            # aggregate compile commands
+            with open(host_path_to_compile_commands, 'r') as f:
+                curr_compile_commnads = json.loads(f.read().strip()[:-1])
+                # translate paths to host paths before writing to file
+                compile_commands.append(curr_compile_commnads)
         objects.append(
             join(relpath(workspace_dir, build_context.conf.project_root),
                  obj_rel_path))
+    if compiler_config.run_clang_tidy:
+        # output aggregate json
+        with open(host_path_to_compile_commands, 'w') as f:
+            json.dump(compile_commands, f)
+        # run clang-tidy
+        for src in sources:
+            clang_tidy_cmd = ([
+                compiler_config.clang_tidy, '-config-file',
+                compiler_config.clang_tidy_config, '-p', buildenv_workspace,
+                join(buildenv_workspace, src)
+            ])
     return objects
 
 

--- a/yabt/cli.py
+++ b/yabt/cli.py
@@ -114,6 +114,9 @@ def make_parser(project_config_file: str) -> configargparse.ArgumentParser:
         PARSER.add('--use-fdebug-prefix-map-flag', action='store_true',
                    help='use the fdebug-preFfix-map CPP debug flag so that ' +
                    'CPP symbolic debug info uses relative paths and not full')
+        PARSER.add('--run-clang-tidy', action='store_true',
+                   help='export clang compilation commands in JSON format and' +
+                   ' run clang-tidy')
         PARSER.add('--no-policies', action='store_true')
         PARSER.add('--no-test-cache', action='store_true',
                    help='Disable YBT test cache')

--- a/yabt/config.py
+++ b/yabt/config.py
@@ -53,6 +53,7 @@ class Config:
         'cmd',
         'default_target_name',
         'use_fdebug_prefix_map_flag',
+        'run_clang_tidy',
         'docker_volume',
         'flavor',
         'force_pull',


### PR DESCRIPTION
1. clang-tidy needs the compile commands in a .json format outline here. Each piece of it is generated by clang (if the right flag is set), and concatenating them all in a list (in a json called compile_commands.json) is what clang-tidy expects in the build directory.
2. Clang-tidy has to run in the build environment where the targets were built, so that it can have access to all the dependencies (including standard library headers) while running. That's why it has to be run inside the buildenv.
3. The expected usage is ```ybt build some_target --run-clang-tidy``` while setting the correct path to clang-tidy and the config file in the YSettings file of the project.