### PR TITLE
support buildkit docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce docker-ce-cli containerd.io docker-buildx-plugin
   # the docker user and password are defined in
   # https://app.travis-ci.com/github/resonai/ybt/settings
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/tests/proto/YRoot
+++ b/tests/proto/YRoot
@@ -14,6 +14,11 @@ ExtDockerImage(
     tag='3.7'
 )
 
+ExtDockerImage(
+    'golang',
+    image='golang',
+    tag='1.18')
+
 DockerImage(
     'proto-builder',
     base_image=':ubuntu',

--- a/tests/proto/YSettings
+++ b/tests/proto/YSettings
@@ -1,3 +1,6 @@
+def known_flavors():
+    return ['debug', 'release']
+
 def get_common_config(config, args):
     return {
         'go_module': 'foo.com',

--- a/tests/proto/app/YBuild
+++ b/tests/proto/app/YBuild
@@ -66,6 +66,6 @@ ProtoCollector('hello1-collector', deps=':hello1-proto')
 GoProg('hello-go',
        sources='hello.go',
        deps=':hello-proto',
-       in_buildenv='//:proto-builder')
+       in_buildenv='//:golang')
 
 GoApp('hello-go-app', base_image='//:ubuntu', main=':hello-go')

--- a/yabt/docker.py
+++ b/yabt/docker.py
@@ -107,13 +107,16 @@ def get_image_name(target):
             else get_safe_path(target.name.lstrip(':')))
 
 
+DOCKER_FALSES = {'0', 'f', 'false'}
+
+
 def format_qualified_image_name(target):
     if target.builder_name == 'ExtDockerImage':
         if target.props.tag:
             return '{}:{}'.format(target.props.image, target.props.tag)
         return target.props.image
     elif hasattr(target, 'image_id') and target.image_id is not None:
-        if os.environ.get('DOCKER_BUILDKIT', '1').lower() in {'0', 'f', 'false'}:
+        if os.environ.get('DOCKER_BUILDKIT', '1').lower() in DOCKER_FALSES:
             return target.image_id
         return '{}:{}'.format(get_image_name(target), target.image_id)
     elif target.builder_name == 'DockerImage':


### PR DESCRIPTION
Support building docker images with buildkit, by tagging each image (foreign or domestic) also with its image ID, and using the image_name:image_id in FROM and as image for docker run.
This works only if buildkit is activated. If DOCKER_BUILDKIT deactivates buildkit in docket, the image name is the ID as before.

Tested all kinds of targets in resonai2, including ones that build intermediate images, with or without cache.

This addresses issue #244 