### PR TITLE
Support upgrade_pip_packages for Docker targets making all the direct pip dependent without a specific version to be upgarded to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ services:
   - docker
 before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce docker-ce-cli containerd.io docker-buildx-plugin
   # the docker user and password are defined in

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 
 # command to run tests
 script:
-  - travis_wait 30 make test
+  - travis_wait 45 make test
 
 jobs:
   include:

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ help:
 	@echo 'Makefile for YABT                                                    '
 	@echo '                                                                     '
 	@echo 'Usage:                                                               '
-	@echo '   make test       Run full test suite with active Python and FLAKE8 '
-	@echo '   make quicktest  Run test suite with active Python and FLAKE8      '
+	@echo '   make test       Run full test suite with active Python and RUFF '
+	@echo '   make quicktest  Run test suite with active Python and RUFF      '
 	@echo '   make lint       Check style for project and tests                 '
 	@echo '   make dist       Build source & wheel distributions                '
 	@echo '   make clean      Clean build & dist output directories             '
@@ -15,10 +15,10 @@ help:
 	@echo '                                                                     '
 
 test:
-	py.test --flake8 --cov=yabt --with-slow
+	py.test --ruff --cov=yabt --with-slow
 
 quicktest:
-	py.test --flake8 --cov=yabt
+	py.test --ruff --cov=yabt
 
 tox:
 	TOXENV=py34,py35,py36 tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ six>=1.13.0
 google-cloud-storage
 
 # For testing
-flake8
+ruff
 pytest>=4.6
 pytest-cov>=2.6.1
-pytest-flake8>=1.0
+pytest-ruff
 tox>=2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,7 @@ six>=1.13.0
 google-cloud-storage
 
 # For testing
-# pinning flake due to: https://github.com/PyCQA/flake8/issues/1419
-flake8<4
+flake8
 pytest>=4.6
 pytest-cov>=2.6.1
 pytest-flake8>=1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,18 @@
 
-[flake8]
-ignore = E252, F401, W504, E722, E121, E123, E126, E305, F811, F841, F901, W605
+[tool.ruff]
+ignore = [
+    "E722",
+    "F401",
+    "F811",
+    "F841",
+    "F901",
+    "W605",
+]
+select = [
+    "E",
+    "F",
+    "W",
+]
 
 [aliases]
 # Use pytest-runner instead of unittest when running `python setup.py test`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,7 @@
 
 [tool.ruff]
-ignore = [
-    "E722",
-    "F401",
-    "F811",
-    "F841",
-    "F901",
-    "W605",
-]
-select = [
-    "E",
-    "F",
-    "W",
-]
+ignore = ["E722", "F401", "F811", "F841", "F901", "W605"]
+select = ["E", "F", "W"]
 
 [aliases]
 # Use pytest-runner instead of unittest when running `python setup.py test`

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     ],
     setup_requires=['pytest-runner'],
     extras_require={
-        'test': ['pytest', 'pytest-cov', 'pytest-flake8'],
+        'test': ['pytest', 'pytest-cov', 'pytest-ruff'],
     },
     zip_safe=True,
     license='Apache License, Version 2.0',

--- a/tests/errors/YSettings
+++ b/tests/errors/YSettings
@@ -22,3 +22,6 @@ def get_policies(conf):
         policy.standard_licenses_only,
         policy.whitelist_licenses_policy('prod', PROD_LICENSES),
     ]
+
+def known_flavors():
+    return ['debug', 'release', 'validate']

--- a/tests/pkgmgrs/YRoot
+++ b/tests/pkgmgrs/YRoot
@@ -119,5 +119,6 @@ AptPackage(
 DockerImage(
     'another-image',
     base_image=':the-image',
-    deps=':gcloud'
+    deps=':gcloud',
+    upgrade_pip_packages=True,
 )

--- a/tests/pkgmgrs/YRoot
+++ b/tests/pkgmgrs/YRoot
@@ -107,7 +107,7 @@ DockerImage(
 AptRepository(
     'gcloud-repository',
     source='deb http://packages.cloud.google.com/apt cloud-sdk-stretch main',
-    key='B53DC80D13EDEF05'
+    key='C0BA5CE6DC6315A3'
 )
 
 AptPackage(

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@
 envlist = py36
 
 [testenv]
-commands = py.test --cov=yabt --flake8 --doctest-modules yabt tests
+commands = py.test --cov=yabt --ruff --doctest-modules yabt tests
 deps =
     pytest
-    pytest-flake8
+    pytest-ruff
     pytest-cov

--- a/yabt/buildcontext.py
+++ b/yabt/buildcontext.py
@@ -33,7 +33,7 @@ import platform
 from subprocess import PIPE
 import sys
 import threading
-from time import sleep, time
+from time import time
 
 import networkx as nx
 from colorama import Fore, Style

--- a/yabt/builders/alias.py
+++ b/yabt/builders/alias.py
@@ -25,7 +25,7 @@ yabt Alias Builder
 
 
 from ..extend import (
-    PropType as PT, register_builder_sig, register_manipulate_target_hook)
+    register_builder_sig, register_manipulate_target_hook)
 
 
 register_builder_sig('Alias')

--- a/yabt/builders/apt_test.py
+++ b/yabt/builders/apt_test.py
@@ -24,7 +24,6 @@ yabt Apt builder tests
 
 import pytest
 
-from . import apt
 from ..pkgmgmt import parse_apt_repository
 from ..target_utils import Target
 

--- a/yabt/builders/cpp.py
+++ b/yabt/builders/cpp.py
@@ -28,7 +28,7 @@ TODO: CppSharedLib builder
 
 
 from hashlib import md5
-from os.path import basename, dirname, join, relpath, splitext
+from os.path import join, relpath, splitext
 
 from ostrich.utils.collections import listify
 
@@ -293,7 +293,6 @@ def link_cpp_artifacts(build_context, target, workspace_dir,
     # include the source & header files of the current target
     # add objects of all dependencies (direct & transitive), if needed
     source_files = target.props.sources + target.props.headers
-    generated_srcs = {}
     objects = []
 
     # add headers of dependencies

--- a/yabt/builders/docker.py
+++ b/yabt/builders/docker.py
@@ -74,6 +74,7 @@ register_builder_sig(
      ('build_user', PT.str, None),
      ('run_user', PT.str, None),
      ('docker_labels', PT.dict, None),
+     ('upgrade_pip_packages', PT.bool, False),
      ])
 
 
@@ -118,7 +119,8 @@ def docker_builder(build_context, target, entrypoint=None, ybt_bin_path=None):
             ybt_bin_path=ybt_bin_path,
             build_user=target.props.build_user,
             run_user=target.props.run_user,
-            labels=target.props.docker_labels))
+            labels=target.props.docker_labels,
+            upgrade_pip_packages=target.props.upgrade_pip_packages))
     target.image_id = metadata['image_id']
     target.artifacts.add(
         AT.docker_image, target.image_id,

--- a/yabt/builders/dockerapp.py
+++ b/yabt/builders/dockerapp.py
@@ -48,6 +48,7 @@ def register_app_builder_sig(builder_name, sig=None, docstring=None):
             ('build_user', PT.str, None),
             ('run_user', PT.str, None),
             ('docker_labels', PT.dict, None),
+            ('upgrade_pip_packages', PT.bool, False),
         ], cachable=False, docstring=docstring)
 
 

--- a/yabt/builders/filegroup.py
+++ b/yabt/builders/filegroup.py
@@ -26,8 +26,7 @@ yabt File group builder
 
 from ..artifact import ArtifactType as AT
 from ..extend import (
-    PropType as PT, register_build_func, register_builder_sig,
-    register_manipulate_target_hook)
+    PropType as PT, register_build_func, register_builder_sig)
 from ..utils import yprint
 
 

--- a/yabt/builders/proto.py
+++ b/yabt/builders/proto.py
@@ -22,15 +22,12 @@ yabt ProtoBuf builder
 """
 
 
-import os
 from os.path import dirname, isfile, join, relpath, splitext
 from pathlib import Path, PurePath
 
-from ostrich.utils.path import commonpath
 from ostrich.utils.text import get_safe_path
 
 from ..artifact import ArtifactType as AT
-from ..compat import walk
 from ..extend import (
     PropType as PT, register_build_func, register_builder_sig,
     register_manipulate_target_hook)

--- a/yabt/builders/proto_test.py
+++ b/yabt/builders/proto_test.py
@@ -20,7 +20,6 @@
 """
 
 
-import os
 from os.path import isdir, isfile, join
 import shutil
 from subprocess import PIPE
@@ -29,10 +28,8 @@ import pytest
 
 from conftest import reset_parser
 from .. import cli, extend
-from . import proto
 from ..buildcontext import BuildContext
 from ..graph import populate_targets_graph
-from ..utils import yprint
 
 
 PROTO_GEN_DIR = 'ybtproto'  # as defined in tests/proto/YSettings

--- a/yabt/builders/python.py
+++ b/yabt/builders/python.py
@@ -73,7 +73,7 @@ register_builder_sig(
 
 
 @register_build_func('Python')
-def python_app_builder(build_context, target):
+def python_lib_builder(build_context, target):
     yprint(build_context.conf, 'Build Python', target)
     for src in chain(target.props.sources, target.props.data):
         target.artifacts.add(AT.app, src)

--- a/yabt/builders/targetgroup.py
+++ b/yabt/builders/targetgroup.py
@@ -24,7 +24,7 @@ yabt Target group builder
 """
 
 
-from ..extend import PropType as PT, register_build_func, register_builder_sig
+from ..extend import register_build_func, register_builder_sig
 from ..utils import yprint
 
 

--- a/yabt/buildfile_parser.py
+++ b/yabt/buildfile_parser.py
@@ -31,7 +31,6 @@ import colorama
 from .config import Config
 from .glob import glob
 from .logging import make_logger
-from .scm import SourceControl
 
 
 logger = make_logger(__name__)
@@ -92,7 +91,7 @@ def process_build_file(buildfile_path: str, build_context, conf: Config):
             # pylint: disable=exec-used
             exec(buildfile.read(), global_context,
                  build_context.get_target_extraction_context(buildfile_path))
-        except:
+        except:  # noqa: E722
             report_buildfile_error(buildfile_path, conf)
         finally:
             os.chdir(curdir)

--- a/yabt/caching.py
+++ b/yabt/caching.py
@@ -24,16 +24,14 @@ TODO: implement also distributed caching
 will require keeping track of which machine produced what, so it is possible
 to rerun "cached" tests on machines with different hardware (for example).
 """
-import itertools
 import json
 import os
 from functools import partial
 from os import makedirs
-from os.path import isdir, isfile, join, relpath, split, dirname
+from os.path import isdir, isfile, join, dirname
 import shutil
 from time import time
 
-from ostrich.utils.text import get_safe_path
 
 from .artifact import ArtifactType as AT
 from .config import Config
@@ -214,7 +212,7 @@ def load_target_from_cache(target: Target, build_context) -> (bool, bool):
                     image_full_name = artifact['dst']
                     try:
                         tag_docker_image(image_id, image_full_name)
-                    except:
+                    except:  # noqa: E722
                         logger.debug('Docker image with ID {} not found '
                                      'locally', image_id)
                         target.artifacts.reset()

--- a/yabt/caching_test.py
+++ b/yabt/caching_test.py
@@ -68,7 +68,7 @@ def test_prebuilt_targets_case2(basic_conf):
 
 @pytest.mark.slow
 @pytest.mark.usefixtures('in_caching_project')
-def test_prebuilt_targets_case1(basic_conf):
+def test_prebuilt_targets_case3(basic_conf):
     """Test pre-built case #3 - unzip & ubuntu should NOT mark as prebuilt.
 
     See issue: https://github.com/resonai/ybt/issues/61

--- a/yabt/compat.py
+++ b/yabt/compat.py
@@ -21,4 +21,3 @@ yabt Compatability module
 :author: Itamar Ostricher
 """
 
-from os import scandir, walk

--- a/yabt/compat.py
+++ b/yabt/compat.py
@@ -20,4 +20,4 @@ yabt Compatability module
 
 :author: Itamar Ostricher
 """
-
+from os import scandir, walk  # noqa: F401

--- a/yabt/config.py
+++ b/yabt/config.py
@@ -32,7 +32,7 @@ from ostrich.utils.text import get_safe_path
 from .extend import Plugin
 from .logging import configure_logging
 from .scm import ScmManager
-from .utils import norm_proj_path, search_for_parent_dir
+from .utils import norm_proj_path
 
 
 BUILD_PROJ_FILE = 'YRoot'

--- a/yabt/docker.py
+++ b/yabt/docker.py
@@ -318,7 +318,7 @@ def build_docker_image(
         distro: dict=None, image_caching_behavior: dict=None,
         runtime_params: dict=None, ybt_bin_path: str=None,
         build_user: str=None, run_user: str=None, labels: dict=None,
-        no_artifacts: bool=False):
+        no_artifacts: bool=False, upgrade_pip_packages: bool=False):
     """Build Docker image, and return a (image_id, image_name:tag) tuple of
        built image, if built successfully.
 
@@ -577,12 +577,14 @@ def build_docker_image(
                     '{pip} install --no-cache-dir --upgrade pip && '
                     .format(pip=pkg_type)
                     if pip_req_cnt[pkg_type] == 0 else '')
+                upgrade_all = '--upgrade' if upgrade_pip_packages else ''
                 dockerfile.extend([
                     'COPY {} /usr/src/\n'.format(req_fname),
                     'RUN {upgrade_pip}'
-                    '{pip} install --no-cache-dir -r /usr/src/{reqs}\n'
+                    '{pip} install {upgrade_all} --no-cache-dir -r '
+                    '/usr/src/{reqs}\n'
                     .format(upgrade_pip=upgrade_pip, pip=pkg_type,
-                            reqs=req_fname)
+                            upgrade_all=upgrade_all, reqs=req_fname)
                 ])
                 pip_req_cnt[pkg_type] += 1
 

--- a/yabt/docker.py
+++ b/yabt/docker.py
@@ -577,11 +577,11 @@ def build_docker_image(
                     '{pip} install --no-cache-dir --upgrade pip && '
                     .format(pip=pkg_type)
                     if pip_req_cnt[pkg_type] == 0 else '')
-                upgrade_all = '--upgrade' if upgrade_pip_packages else ''
+                upgrade_all = ' --upgrade ' if upgrade_pip_packages else ' '
                 dockerfile.extend([
                     'COPY {} /usr/src/\n'.format(req_fname),
                     'RUN {upgrade_pip}'
-                    '{pip} install {upgrade_all} --no-cache-dir -r '
+                    '{pip} install{upgrade_all}--no-cache-dir -r '
                     '/usr/src/{reqs}\n'
                     .format(upgrade_pip=upgrade_pip, pip=pkg_type,
                             upgrade_all=upgrade_all, reqs=req_fname)

--- a/yabt/docker_test.py
+++ b/yabt/docker_test.py
@@ -27,7 +27,7 @@ import pytest
 from subprocess import check_output, PIPE
 
 from .buildcontext import BuildContext
-from .graph import populate_targets_graph, topological_sort
+from .graph import populate_targets_graph
 from .yabt import cmd_build
 
 

--- a/yabt/global_cache.py
+++ b/yabt/global_cache.py
@@ -38,7 +38,7 @@ class GlobalCache:
         """
         returns True if the cache has a target matching the hash
         """
-        raise NotImplemented('Method has_cache of class {} was not '
+        raise NotImplementedError('Method has_cache of class {} was not '
                              'implemented'.format(self.__class__.__name__))
 
     def download_summary(self, target_hash: str, dst: str) -> bool:
@@ -47,7 +47,7 @@ class GlobalCache:
 
         Returns True if download worked, False otherwise
         """
-        raise NotImplemented('Method download_summary of class {} was not '
+        raise NotImplementedError('Method download_summary of class {} was not '
                              'implemented'.format(self.__class__.__name__))
 
     def download_artifacts_meta(self, target_hash: str, dst: str) -> bool:
@@ -57,7 +57,7 @@ class GlobalCache:
 
         Returns True if download worked, False otherwise
         """
-        raise NotImplemented(
+        raise NotImplementedError(
             'Method download_artifacts_meta of class {} was not '
             'implemented'.format(self.__class__.__name__))
 
@@ -68,7 +68,7 @@ class GlobalCache:
 
         Returns True if download worked, False otherwise
         """
-        raise NotImplemented(
+        raise NotImplementedError(
             'Method download_test_cache of class {} was not '
             'implemented'.format(self.__class__.__name__))
 
@@ -83,18 +83,18 @@ class GlobalCache:
         :param dst: the directory to download the artifacts to
         :return: True if download worked, False otherwise
         """
-        raise NotImplemented('Method download_artifacts of class {} was not '
+        raise NotImplementedError('Method download_artifacts of class {} was not '
                              'implemented'.format(self.__class__.__name__))
 
     def create_target_cache(self, target_hash: str):
-        raise NotImplemented('Method create_target_cache of class {} was not '
+        raise NotImplementedError('Method create_target_cache of class {} was not '
                              'implemented'.format(self.__class__.__name__))
 
     def upload_summary(self, target_hash: str, src: str):
         """
         Upload summary file in `src` describing the target with the given hash
         """
-        raise NotImplemented('Method upload_summary of class {} was not '
+        raise NotImplementedError('Method upload_summary of class {} was not '
                              'implemented'.format(self.__class__.__name__))
 
     def upload_artifacts_meta(self, target_hash: str, src: str):
@@ -102,7 +102,7 @@ class GlobalCache:
         Upload the metadata file in `src` describing the artifcats cached for
         the target.
         """
-        raise NotImplemented(
+        raise NotImplementedError(
             'Method upload_artifacts_meta of class {} was not '
             'implemented'.format(self.__class__.__name__))
 
@@ -114,12 +114,12 @@ class GlobalCache:
                                     the required permissions as values.
         :param src: the directory containing the artifacts.
         """
-        raise NotImplemented('Method upload_artifacts of class {} was not '
+        raise NotImplementedError('Method upload_artifacts of class {} was not '
                              'implemented'.format(self.__class__.__name__))
 
     def upload_test_cache(self, target_hash: str, src: str):
         """
         Upload the test data in `src` describing the successful test.
         """
-        raise NotImplemented('Method upload_test_cache of class {} was not '
+        raise NotImplementedError('Method upload_test_cache of class {} was not '
                              'implemented'.format(self.__class__.__name__))

--- a/yabt/logging.py
+++ b/yabt/logging.py
@@ -40,7 +40,7 @@ class Message:  # pylint: disable=too-few-public-methods
     def __str__(self):
         try:
             return self.fmt.format(*self.args)
-        except:
+        except Exception:
             # Sometimes we just want to log something with {}, with no
             # formatting. json for example.
             return self.fmt

--- a/yabt/policy.py
+++ b/yabt/policy.py
@@ -21,21 +21,9 @@ yabt Policy module
 :author: Itamar Ostricher
 """
 
-import json
-from os import makedirs
-from os.path import isdir, isfile, join, relpath, split
-import shutil
-from time import time
 
-from ostrich.utils.text import get_safe_path
 
-from .artifact import ArtifactType as AT
-from .config import Config
-from .docker import get_image_name, handle_build_cache, tag_docker_image
-from .graph import get_descendants
 from .logging import make_logger
-from .target_utils import ImageCachingBehavior, Target
-from .utils import hash_tree, rmnode, rmtree
 
 
 logger = make_logger(__name__)

--- a/yabt/target_extraction.py
+++ b/yabt/target_extraction.py
@@ -30,7 +30,7 @@ from ostrich.utils.collections import listify
 from .buildfile_utils import to_build_module
 from .extend import Builder, Empty, Plugin, PropType as PT
 from .logging import make_logger
-from .target_utils import norm_name, split_build_module, Target, validate_name
+from .target_utils import norm_name, Target, validate_name
 from .utils import norm_proj_path
 
 
@@ -173,7 +173,6 @@ def extractor(
         target = Target(builder_name=builder_name)
         # convert args/kwargs to target.props and handle arg types
         args_to_props(target, builder, args, kwargs)
-        raw_name = target.props.name
         handle_typed_args(target, builder, build_module)
         logger.debug('Extracting target: {}', target)
         # promote the `name` and `deps` from props to the target instance

--- a/yabt/target_extraction_test.py
+++ b/yabt/target_extraction_test.py
@@ -26,11 +26,9 @@ from os import path
 
 import pytest
 
-from .buildcontext import BuildContext
 from .extend import (
-    Plugin, PropType as PT, register_build_func, register_builder_sig,
-    register_manipulate_target_hook)
-from .target_extraction import args_to_props, extractor, handle_typed_args
+    Plugin, PropType as PT, register_builder_sig)
+from .target_extraction import args_to_props, handle_typed_args
 from .target_utils import Target
 
 

--- a/yabt/target_utils.py
+++ b/yabt/target_utils.py
@@ -22,7 +22,6 @@ yabt target utils module
 """
 
 
-from collections import defaultdict
 from hashlib import md5
 import json
 from os.path import join, normpath
@@ -35,7 +34,6 @@ from ostrich.utils.text import get_safe_path
 
 from .artifact import ArtifactStore
 from .extend import Plugin, PropType as PT
-from .compat import walk
 from .config import Config
 from .utils import hash_tree, norm_proj_path
 

--- a/yabt/target_utils_test.py
+++ b/yabt/target_utils_test.py
@@ -93,8 +93,8 @@ def test_norm_name_unqualified_error():
             'possible ambiguity' in str(excinfo.value))
 
 
-_HELLO_PROG_HASH = '5ff09c1f31f365d4872ba3e54090fe3d'
-_PROTO_BUILDER = '3e84e7cfe5498c22f258757622fa12c3'
+_HELLO_PROG_HASH = 'aabad8062b3cb3ba305a8dc4eab2d19e'
+_PROTO_BUILDER = '8b411e2e06fa86d9d7301bb60d10d371'
 _BOTH_HASHES = list(sorted([_HELLO_PROG_HASH, _PROTO_BUILDER]))
 
 
@@ -133,6 +133,7 @@ _EXP_JSON = """{
         "policies": [],
         "run_user": null,
         "runtime_params": {},
+        "upgrade_pip_packages": false,
         "work_dir": "/usr/src/app"
     },
     "tags": []

--- a/yabt/utils_test.py
+++ b/yabt/utils_test.py
@@ -24,7 +24,6 @@ yabt utils tests
 
 from os.path import join
 
-import pytest
 
 from .utils import hash_tree, hash_file
 


### PR DESCRIPTION
#252 

Since it seems the CI/CD is broken I'm also fixing the CI/CD
And switching the project from flake8 to ruff